### PR TITLE
Add P2P attachment streaming and TxHashSet sync

### DIFF
--- a/mimblewimble/blockchain.py
+++ b/mimblewimble/blockchain.py
@@ -1,5 +1,7 @@
 import hashlib
 import json  # TODO remove after debugging
+import time
+from datetime import datetime, timezone
 from io import BytesIO
 
 from mimblewimble.mmr.index import MMRIndex
@@ -12,6 +14,46 @@ from mimblewimble.models.transaction import TransactionInput
 from mimblewimble.models.transaction import TransactionOutput
 from mimblewimble.models.transaction import TransactionBody
 from mimblewimble.models.transaction import BlindingFactor
+from mimblewimble.models.transaction import TransactionKernel, EKernelFeatures
+
+
+class HeaderValidationError(ValueError):
+    """Raised when a block header fails validation."""
+
+    pass
+
+
+class BlockValidationError(ValueError):
+    """Raised when a full block fails validation."""
+
+    pass
+
+
+def _kernel_signing_msg(kernel: "TransactionKernel") -> bytes:
+    """Compute the 32-byte blake2b signing message for a TransactionKernel.
+
+    Matches Grin's KernelFeatures::kernel_sig_msg() in core/src/core/transaction.rs:
+        blake2b_256(feature_byte [| fee_u64_be] [| lock_or_rel_height_be])
+    """
+    msg_bytes = bytearray()
+    features = kernel.getFeatures()
+    msg_bytes.append(features.value)
+
+    if features == EKernelFeatures.DEFAULT_KERNEL:
+        fee_val = kernel.getFee().getFee() if kernel.getFee() is not None else 0
+        msg_bytes += fee_val.to_bytes(8, "big")
+    elif features == EKernelFeatures.COINBASE_KERNEL:
+        pass  # just the feature byte
+    elif features == EKernelFeatures.HEIGHT_LOCKED:
+        fee_val = kernel.getFee().getFee() if kernel.getFee() is not None else 0
+        msg_bytes += fee_val.to_bytes(8, "big")
+        msg_bytes += kernel.getLockHeight().to_bytes(8, "big")
+    elif features == EKernelFeatures.NO_RECENT_DUPLICATE:
+        fee_val = kernel.getFee().getFee() if kernel.getFee() is not None else 0
+        msg_bytes += fee_val.to_bytes(8, "big")
+        msg_bytes += kernel.getLockHeight().to_bytes(2, "big")
+
+    return hashlib.blake2b(bytes(msg_bytes), digest_size=32).digest()
 
 
 class ProofOfWork:
@@ -73,6 +115,10 @@ class ProofOfWork:
     def getHash(self):
         cycle = self.serializeCycle()
         return hashlib.blake2b(cycle, digest_size=32).digest()
+
+    @property
+    def is_secondary(self) -> bool:
+        return self.isSecondary()
 
 
 class BlockHeader:
@@ -158,6 +204,26 @@ class BlockHeader:
 
     def isSecondaryPoW(self):
         return self.proofOfWork.isSecondary()
+
+    # Compatibility properties for DifficultyCalculator / DifficultyLoader
+    # These expose snake_case aliases expected by the difficulty subsystem.
+
+    @property
+    def prev_hash(self) -> str:
+        """Hex-encoded previous block hash (key format for IBlockDB lookups)."""
+        return self.previousBlockHash.hex()
+
+    @property
+    def total_difficulty(self) -> int:
+        return self.totalDifficulty
+
+    @property
+    def scaling_difficulty(self) -> int:
+        return self.scalingDifficulty
+
+    @property
+    def proof_of_work(self) -> "ProofOfWork":
+        return self.proofOfWork
 
     # Merklish root stuffz
 
@@ -247,13 +313,17 @@ class BlockHeader:
         for proofNonce in self.getProofOfWork().getProofNonces():
             cuckooSolution += proofNonce.to_bytes(8, "big")
 
+        ts_utc = datetime.fromtimestamp(
+            self.getTimestamp(), tz=timezone.utc
+        ).isoformat()
+
         return {
             "height": self.getHeight(),
             "hash": self.getHash().hex(),
             "version": self.getVersion(),
             "timestamp_raw": self.getTimestamp(),
-            "timestamp_local": self.getTimestamp(),  # TODO convert to local
-            "timestamp": self.getTimestamp(),  # TODO convert to UTC
+            "timestamp_local": ts_utc,
+            "timestamp": ts_utc,
             "previous": self.getPreviousHash().hex(),
             "prev_root": self.getPreviousRoot().hex(),
             "kernel_root": self.getKernelRoot().hex(),
@@ -334,6 +404,118 @@ class BlockHeader:
     def shortHash(self):
         # TODO
         pass
+
+    def validate(
+        self,
+        prev_header: "BlockHeader | None" = None,
+        block_db=None,
+        current_time: int | None = None,
+    ) -> None:
+        """Validate this header.  Raises :class:`HeaderValidationError` on failure."""
+        validate_header(
+            self, prev_header=prev_header, block_db=block_db, current_time=current_time
+        )
+
+
+def validate_header(
+    header: "BlockHeader",
+    prev_header: "BlockHeader | None" = None,
+    block_db=None,
+    current_time: int | None = None,
+) -> None:
+    """Validate a single block header.
+
+    Checks (in order):
+      1. Timestamp is not too far in the future.
+      2. Chain-linking: prev_hash / height match *prev_header* when supplied.
+      3. Proof-of-Work solution is valid for the declared algorithm.
+      4. Declared difficulty meets the next-difficulty target (requires *block_db*).
+
+    Args:
+        header:       The :class:`BlockHeader` to validate.
+        prev_header:  The immediately preceding :class:`BlockHeader`, if available.
+        block_db:     An :class:`~mimblewimble.pow.blockdb.IBlockDB` instance used
+                      to compute the expected next-difficulty.  When ``None`` the
+                      difficulty check is skipped.
+        current_time: Current Unix epoch (seconds).  Defaults to ``time.time()``.
+
+    Raises:
+        HeaderValidationError: on any validation failure.
+    """
+    from mimblewimble.pow.algos import pow_validate
+
+    now = current_time if current_time is not None else int(time.time())
+
+    # 1. Timestamp: reject blocks more than FTL seconds in the future
+    max_ts = now + int(Consensus.default_future_time_limit_sec)
+    if header.getTimestamp() > max_ts:
+        raise HeaderValidationError(
+            f"Header timestamp {header.getTimestamp()} too far in future "
+            f"(max {max_ts}, height={header.getHeight()})"
+        )
+
+    # 2. Chain-linking
+    if prev_header is not None:
+        if header.getPreviousHash() != prev_header.getHash():
+            raise HeaderValidationError(
+                f"Header prev_hash mismatch at height {header.getHeight()}: "
+                f"expected {prev_header.getHash().hex()[:12]}… "
+                f"got {header.getPreviousHash().hex()[:12]}…"
+            )
+        if header.getHeight() != prev_header.getHeight() + 1:
+            raise HeaderValidationError(
+                f"Header height {header.getHeight()} expected "
+                f"{prev_header.getHeight() + 1}"
+            )
+
+    # 3. Proof-of-Work
+    # Build the dict that pow_validate() expects; cuckoo_solution must be List[int].
+    header_dict = header.toJSON()
+    header_dict["cuckoo_solution"] = header.getProofNonces()
+    # serialize_pre_pow uses the raw timestamp int when present
+    header_dict["timestamp"] = header.getTimestamp()
+
+    result = pow_validate(header_dict)
+    # pow_validate returns (bool, status) for all algorithm variants
+    if isinstance(result, tuple):
+        valid, status = result
+    else:
+        # Older algo wrappers may return just the status code
+        from mimblewimble.pow.common import EPoWStatus
+
+        valid = result == EPoWStatus.POW_OK
+        status = result
+
+    if not valid:
+        raise HeaderValidationError(
+            f"Header PoW invalid (status={status}, height={header.getHeight()}, "
+            f"edge_bits={header.getEdgeBits()})"
+        )
+
+    # 4. Difficulty target check (optional; requires previous-header chain in block_db)
+    if block_db is not None and header.getHeight() > 0:
+        try:
+            from mimblewimble.pow.difficulty_calculator import DifficultyCalculator
+
+            calc = DifficultyCalculator(block_db)
+            expected = calc.calculate_next_difficulty(header)
+            expected_diff = expected.get_difficulty()
+            if prev_header is not None:
+                block_diff = (
+                    header.getTotalDifficulty() - prev_header.getTotalDifficulty()
+                )
+            else:
+                block_diff = header.getTotalDifficulty()
+            if block_diff < expected_diff:
+                raise HeaderValidationError(
+                    f"Header difficulty {block_diff} below minimum {expected_diff} "
+                    f"(height={header.getHeight()})"
+                )
+        except HeaderValidationError:
+            raise
+        except Exception:
+            # Not enough history to compute difficulty; skip rather than fail.
+            pass
 
 
 class FullBlock:
@@ -417,6 +599,204 @@ class FullBlock:
     def markAsValidated(self):
         self.validated = True
 
+    # ------------------------------------------------------------------
+    # Validation
+    # ------------------------------------------------------------------
+
+    def validate(
+        self,
+        prev_header: "BlockHeader | None" = None,
+        block_db=None,
+        current_time: int | None = None,
+    ) -> None:
+        """Validate this block end-to-end.
+
+        Checks:
+          1. Header PoW, timestamp, chain-linking, and difficulty.
+          2. Block weight does not exceed the protocol limit.
+          3. Coinbase output/kernel consistency (reward + fees balance).
+          4. Kernel excess sum (Mimblewimble balance equation).
+          5. Output rangeproofs (Bulletproof batch verify).
+          6. Kernel Schnorr signatures (batch verify).
+          7. Kernel lock-height constraints.
+
+        Args:
+            prev_header:  The immediately preceding block header (for chain-linking
+                          and difficulty checks).  May be ``None`` for genesis.
+            block_db:     An :class:`~mimblewimble.pow.blockdb.IBlockDB` for the
+                          difficulty check.  Skipped when ``None``.
+            current_time: Current Unix epoch seconds; defaults to ``time.time()``.
+
+        Raises:
+            HeaderValidationError: if the header is invalid.
+            BlockValidationError:  if the block body is invalid.
+        """
+        # 1. Header
+        validate_header(
+            self.header,
+            prev_header=prev_header,
+            block_db=block_db,
+            current_time=current_time,
+        )
+
+        # 2. Block weight
+        height = self.getHeight()
+        version = self.header.getVersion()
+        if version >= 5:
+            weight = Consensus.calculateWeightV5(
+                len(self.getInputs()),
+                len(self.getOutputs()),
+                len(self.getKernels()),
+            )
+        else:
+            weight = Consensus.calculateWeightV4(
+                len(self.getInputs()),
+                len(self.getOutputs()),
+                len(self.getKernels()),
+            )
+        if weight > Consensus.max_block_weight:
+            raise BlockValidationError(
+                f"Block weight {weight} exceeds max {Consensus.max_block_weight} "
+                f"(height={height})"
+            )
+
+        # 3. Coinbase consistency
+        self._verify_coinbase(height)
+
+        # 4. Kernel excess sum (Mimblewimble balance)
+        self._verify_kernel_sum()
+
+        # 5. Rangeproofs
+        self._verify_rangeproofs()
+
+        # 6. Kernel signatures
+        self._verify_kernel_signatures()
+
+        # 7. Lock heights
+        self._verify_lock_heights(height)
+
+        self.validated = True
+
+    def _verify_coinbase(self, height: int) -> None:
+        """Verify exactly one coinbase output and kernel, and that their
+        commitments balance against the block reward + total transaction fees."""
+        from mimblewimble.crypto.pedersen import Pedersen
+        from mimblewimble.models.transaction import EKernelFeatures
+
+        cb_outputs = [o for o in self.getOutputs() if o.isCoinbase()]
+        cb_kernels = [k for k in self.getKernels() if k.isCoinbase()]
+
+        if len(cb_outputs) != 1 or len(cb_kernels) != 1:
+            raise BlockValidationError(
+                f"Block must have exactly one coinbase output and kernel "
+                f"(outputs={len(cb_outputs)}, kernels={len(cb_kernels)}, "
+                f"height={height})"
+            )
+
+        cb_output = cb_outputs[0]
+        cb_kernel = cb_kernels[0]
+
+        # Total fees from non-coinbase kernels
+        tx_fees = sum(
+            k.getFee().getFee()
+            for k in self.getKernels()
+            if not k.isCoinbase() and k.getFee() is not None
+        )
+        reward_value = int(Consensus.reward) + tx_fees
+
+        pedersen = Pedersen()
+        from mimblewimble.models.transaction import BlindingFactor as _BF
+
+        reward_commit = pedersen.commit(reward_value, _BF.zero())
+        expected = pedersen.commitSum(
+            [cb_kernel.getExcessCommitment(), reward_commit], []
+        )
+
+        if cb_output.getCommitment().getBytes() != expected.getBytes():
+            raise BlockValidationError(
+                f"Coinbase output commitment does not match kernel excess + reward "
+                f"(height={height})"
+            )
+
+    def _verify_kernel_sum(self) -> None:
+        """Verify the Mimblewimble kernel-sum equation for this block:
+        sum(output_commits) - sum(input_commits) - fees*H
+        == sum(kernel_excesses) + kernel_offset*G
+        """
+        from mimblewimble.crypto.pedersen import Pedersen
+        from mimblewimble.models.transaction import BlindingFactor as _BF
+
+        pedersen = Pedersen()
+
+        output_commits = [o.getCommitment() for o in self.getOutputs()]
+        input_commits = [i.getCommitment() for i in self.getInputs()]
+        kernel_excess_commits = [k.getExcessCommitment() for k in self.getKernels()]
+
+        total_fees = sum(
+            k.getFee().getFee()
+            for k in self.getKernels()
+            if not k.isCoinbase() and k.getFee() is not None
+        )
+        fees_commit = pedersen.commit(total_fees, _BF.zero())
+
+        offset_bytes = self.getTotalKernelOffset().getBytes()
+        offset_commit = pedersen.commit(0, _BF(offset_bytes))
+
+        # utxo_sum = sum(outputs) - sum(inputs) - fees*H
+        utxo_sum = pedersen.commitSum(output_commits, input_commits + [fees_commit])
+        # kern_sum = sum(kernel_excesses) + offset*G
+        kern_sum = pedersen.commitSum(kernel_excess_commits + [offset_commit], [])
+
+        if utxo_sum.getBytes() != kern_sum.getBytes():
+            raise BlockValidationError(
+                f"Kernel sum mismatch at height={self.getHeight()}: "
+                f"utxo_sum={utxo_sum.getBytes().hex()[:12]}… "
+                f"kern_sum={kern_sum.getBytes().hex()[:12]}…"
+            )
+
+    def _verify_rangeproofs(self) -> None:
+        """Batch-verify all output bulletproof rangeproofs."""
+        from mimblewimble.crypto.bulletproof import Bulletproof
+
+        outputs = self.getOutputs()
+        if not outputs:
+            return
+        bp = Bulletproof()
+        pairs = [(o.getCommitment(), o.getRangeProof()) for o in outputs]
+        if not bp.verifyBulletproofs(pairs):
+            raise BlockValidationError(
+                f"Rangeproof verification failed at height={self.getHeight()}"
+            )
+
+    def _verify_kernel_signatures(self) -> None:
+        """Batch-verify all kernel Schnorr signatures."""
+        from mimblewimble.crypto.aggsig import AggSig
+
+        kernels = self.getKernels()
+        if not kernels:
+            return
+        agg = AggSig()
+        signatures = [k.getExcessSignature() for k in kernels]
+        commitments = [k.getExcessCommitment() for k in kernels]
+        messages = [_kernel_signing_msg(k) for k in kernels]
+        if not agg.verifyAggregateSignatures(signatures, commitments, messages):
+            raise BlockValidationError(
+                f"Kernel signature verification failed at height={self.getHeight()}"
+            )
+
+    def _verify_lock_heights(self, height: int) -> None:
+        """Verify kernel lock heights are not in the future."""
+        from mimblewimble.models.transaction import EKernelFeatures
+
+        for kernel in self.getKernels():
+            features = kernel.getFeatures()
+            if features == EKernelFeatures.HEIGHT_LOCKED:
+                if kernel.getLockHeight() > height:
+                    raise BlockValidationError(
+                        f"Kernel lock height {kernel.getLockHeight()} > "
+                        f"block height {height}"
+                    )
+
 
 class CompactBlock:
     def __init__(self, header, nonce, fullOutputs, fullKernels, shortIds):
@@ -455,6 +835,8 @@ class CompactBlock:
     # serialization / deserialization
 
     def serialize(self):
+        from io import BytesIO as _BytesIO
+
         # nonce is 8 bytes (uint64 big-endian)
         bytes_nonce = self.nonce.to_bytes(8, "big")
 
@@ -462,14 +844,23 @@ class CompactBlock:
         bytes_num_kernels = len(self.getKernels()).to_bytes(2, "big")
         bytes_num_short_ids = len(self.getShortIds()).to_bytes(2, "big")
 
-        outputs = self.getOutputs()
-        bytes_outputs = b"".join(_output.serialize() for _output in outputs)
+        # Outputs require a Serializer (not a raw BytesIO)
+        output_ser = Serializer()
+        for _output in self.getOutputs():
+            _output.serialize(output_ser)
+        bytes_outputs = output_ser.getvalue()
 
-        kernels = self.getKernels()
-        bytes_kernels = b"".join(_kernel.serialize() for _kernel in kernels)
+        # Kernels require a Serializer
+        kernel_ser = Serializer()
+        for _kernel in self.getKernels():
+            _kernel.serialize(kernel_ser)
+        bytes_kernels = kernel_ser.getvalue()
 
-        short_ids = self.getShortIds()
-        bytes_short_ids = b"".join(_short_id.serialize() for _short_id in short_ids)
+        # ShortId.serialize takes a BytesIO
+        short_id_buf = _BytesIO()
+        for _short_id in self.getShortIds():
+            _short_id.serialize(short_id_buf)
+        bytes_short_ids = short_id_buf.getvalue()
 
         return (
             bytes_nonce

--- a/mimblewimble/mmr/txhashset.py
+++ b/mimblewimble/mmr/txhashset.py
@@ -22,6 +22,8 @@ from __future__ import annotations
 
 import json
 import logging
+import os
+import shutil
 import time
 from io import BytesIO
 from pathlib import Path
@@ -975,6 +977,44 @@ class TxHashSet:
         self.output_pmmr.close()
         self.rangeproof_pmmr.close()
         self.kernel_mmr.close()
+
+    def replace_directory(self, source_dir: Path) -> None:
+        """Replace this TxHashSet with a validated directory and reopen it."""
+        source_dir = Path(source_dir)
+        if not source_dir.is_dir():
+            raise TxHashSetError(f"TxHashSet source directory is missing: {source_dir}")
+        if source_dir.resolve() == self._dir.resolve():
+            return
+
+        backup_dir = self._dir.with_name(f"{self._dir.name}.backup")
+        if backup_dir.exists():
+            shutil.rmtree(backup_dir)
+
+        self.close()
+        moved_old = False
+        try:
+            if self._dir.exists():
+                os.replace(self._dir, backup_dir)
+                moved_old = True
+            os.replace(source_dir, self._dir)
+            reopened = TxHashSet(self._dir)
+            self.output_pmmr = reopened.output_pmmr
+            self.rangeproof_pmmr = reopened.rangeproof_pmmr
+            self.kernel_mmr = reopened.kernel_mmr
+            self._commit_to_pos = reopened._commit_to_pos
+            if backup_dir.exists():
+                shutil.rmtree(backup_dir)
+        except Exception:
+            if self._dir.exists() and not moved_old:
+                shutil.rmtree(self._dir)
+            if moved_old and backup_dir.exists() and not self._dir.exists():
+                os.replace(backup_dir, self._dir)
+            reopened = TxHashSet(self._dir)
+            self.output_pmmr = reopened.output_pmmr
+            self.rangeproof_pmmr = reopened.rangeproof_pmmr
+            self.kernel_mmr = reopened.kernel_mmr
+            self._commit_to_pos = reopened._commit_to_pos
+            raise
 
     def _save_commit_idx(self) -> None:
         idx_path = self._dir / self._COMMIT_IDX_FILE

--- a/mimblewimble/p2p/adapter.py
+++ b/mimblewimble/p2p/adapter.py
@@ -102,6 +102,56 @@ class ChainAdapter(ABC):
     def receive_kernel_segment(self, block_hash: bytes, segment) -> None:
         """Process an inbound kernel MMR segment."""
 
+    # ------------------------------------------------------------------
+    # Block sync
+    # ------------------------------------------------------------------
+
+    @abstractmethod
+    def handle_block(self, block_hash: bytes, raw_block: bytes) -> bool:
+        """Deserialise, validate, and store a full block received from a peer.
+
+        Args:
+            block_hash: The 32-byte hash of the block (from the GetBlock request).
+            raw_block:  The raw serialised :class:`~mimblewimble.blockchain.FullBlock`
+                        bytes as received on the wire.
+
+        Returns:
+            True if the block was accepted; False if it was a duplicate.
+
+        Raises:
+            :class:`~mimblewimble.blockchain.BlockValidationError` on invalid block.
+        """
+
+    @abstractmethod
+    def handle_compact_block(self, raw_compact_block: bytes) -> bool:
+        """Process a compact block received from a peer.
+
+        Implementations should:
+          1. Deserialise the header and short-IDs.
+          2. Match short-IDs against the local mempool / known transactions.
+          3. If all transactions are known, reconstruct the full block and
+             call :meth:`handle_block`.
+          4. If any transaction is unknown, request it via ``GetTransaction``.
+
+        Returns True if the block was fully reconstructed and accepted.
+        """
+
+    # ------------------------------------------------------------------
+    # Transaction pool
+    # ------------------------------------------------------------------
+
+    @abstractmethod
+    def handle_transaction(self, raw_tx: bytes, from_stem: bool = False) -> bool:
+        """Validate and add an inbound transaction to the pool.
+
+        Args:
+            raw_tx:    Raw serialised transaction bytes.
+            from_stem: True if arrived via the Dandelion++ stem path
+                       (``StemTransaction`` message type).
+
+        Returns True if added; False if already known.
+        """
+
 
 class NoopChainAdapter(ChainAdapter):
     """Dummy adapter that does nothing — useful for unit-testing the P2P layer."""
@@ -138,3 +188,12 @@ class NoopChainAdapter(ChainAdapter):
 
     def receive_kernel_segment(self, block_hash: bytes, segment) -> None:
         pass
+
+    def handle_block(self, block_hash: bytes, raw_block: bytes) -> bool:
+        return False
+
+    def handle_compact_block(self, raw_compact_block: bytes) -> bool:
+        return False
+
+    def handle_transaction(self, raw_tx: bytes, from_stem: bool = False) -> bool:
+        return False

--- a/mimblewimble/p2p/adapter.py
+++ b/mimblewimble/p2p/adapter.py
@@ -99,6 +99,9 @@ class ChainAdapter(ABC):
     ) -> None:
         """Register the active streamed TxHashSet archive consumer."""
 
+    def set_body_sync_handler(self, handler: Optional[Callable[[str], None]]) -> None:
+        """Register the active body-sync completion callback."""
+
     # ------------------------------------------------------------------
     # PIBD segments
     # ------------------------------------------------------------------
@@ -201,6 +204,9 @@ class NoopChainAdapter(ChainAdapter):
 
     def txhashset_write(self, block_hash: bytes, height: int, zip_bytes: bytes) -> bool:
         return False
+
+    def set_body_sync_handler(self, handler: Optional[Callable[[str], None]]) -> None:
+        pass
 
     def receive_bitmap_segment(self, block_hash: bytes, segment) -> None:
         pass

--- a/mimblewimble/p2p/adapter.py
+++ b/mimblewimble/p2p/adapter.py
@@ -13,7 +13,9 @@ Reference: p2p/src/types.rs (ChainAdapter trait in Grin)
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import List, Optional, Tuple
+from typing import Callable, List, Optional, Tuple
+
+from mimblewimble.mmr.segment import SegmentType
 
 
 class ChainAdapter(ABC):
@@ -85,6 +87,14 @@ class ChainAdapter(ABC):
     # ------------------------------------------------------------------
     # PIBD segments
     # ------------------------------------------------------------------
+
+    def set_pibd_segment_handler(
+        self, handler: Optional[Callable[[SegmentType, bytes, object], None]]
+    ) -> None:
+        """Register the active PIBD segment consumer.
+
+        Adapters without a StateSync integration may ignore this hook.
+        """
 
     @abstractmethod
     def receive_bitmap_segment(self, block_hash: bytes, segment) -> None:

--- a/mimblewimble/p2p/adapter.py
+++ b/mimblewimble/p2p/adapter.py
@@ -94,6 +94,11 @@ class ChainAdapter(ABC):
         """Consume a streamed TxHashSet archive without buffering it in memory."""
         return self.txhashset_write(block_hash, height, archive.read())
 
+    def set_txhashset_stream_handler(
+        self, handler: Optional[Callable[[bytes, int, BinaryIO, int], bool]]
+    ) -> None:
+        """Register the active streamed TxHashSet archive consumer."""
+
     # ------------------------------------------------------------------
     # PIBD segments
     # ------------------------------------------------------------------

--- a/mimblewimble/p2p/adapter.py
+++ b/mimblewimble/p2p/adapter.py
@@ -13,7 +13,7 @@ Reference: p2p/src/types.rs (ChainAdapter trait in Grin)
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Callable, List, Optional, Tuple
+from typing import BinaryIO, Callable, List, Optional, Tuple
 
 from mimblewimble.mmr.segment import SegmentType
 
@@ -83,6 +83,16 @@ class ChainAdapter(ABC):
 
         Returns True if the ZIP was accepted and the chain state updated.
         """
+
+    def txhashset_write_stream(
+        self,
+        block_hash: bytes,
+        height: int,
+        archive: BinaryIO,
+        size: int,
+    ) -> bool:
+        """Consume a streamed TxHashSet archive without buffering it in memory."""
+        return self.txhashset_write(block_hash, height, archive.read())
 
     # ------------------------------------------------------------------
     # PIBD segments

--- a/mimblewimble/p2p/body_sync.py
+++ b/mimblewimble/p2p/body_sync.py
@@ -1,0 +1,211 @@
+"""
+mimblewimble/p2p/body_sync.py
+
+BodySync — Stage 3 of Grin node sync: download full block bodies for the
+range between the genesis/horizon and the current best header.
+
+After PIBD (Stage 2) completes we have all UTXO commitments but no block
+bodies between the horizon and the chain tip.  BodySync fills that gap by
+issuing ``GetBlock`` requests and validating received ``Block`` responses.
+
+The in-flight request pattern mirrors :class:`~mimblewimble.p2p.state_sync.StateSync`.
+
+Reference: servers/src/grin/sync/body_sync.rs
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Set
+
+from mimblewimble.p2p.adapter import ChainAdapter
+from mimblewimble.p2p.peer import Peer
+from mimblewimble.p2p.peers import PeerStore
+
+log = logging.getLogger(__name__)
+
+# Maximum number of simultaneous in-flight block requests per peer
+BLOCK_REQUEST_BATCH_SIZE: int = 16
+
+# Seconds before an in-flight request is considered stale and re-queued
+BLOCK_REQUEST_TIMEOUT_SECS: float = 30.0
+
+# How often (seconds) to log a body-sync progress summary
+LOG_INTERVAL: float = 30.0
+
+
+@dataclass
+class _InFlight:
+    """Tracks a single outstanding GetBlock request."""
+
+    hash_hex: str
+    height: int
+    peer_addr: str
+    requested_at: float = field(default_factory=time.monotonic)
+
+
+class BodySyncError(Exception):
+    pass
+
+
+class BodySync:
+    """Download and validate full block bodies from the tip down to the horizon.
+
+    Usage::
+
+        body_sync = BodySync(adapter, peers, start_height=1, end_height=best_height)
+        while not body_sync.is_complete():
+            body_sync.check_run()
+            time.sleep(0.5)
+
+    Args:
+        adapter:      ChainAdapter; its ``handle_block`` stores validated blocks.
+        peers:        Live peer collection.
+        start_height: First height needing a body (usually 1; genesis has no txs).
+        end_height:   Last height to download (inclusive, typically best-header height).
+    """
+
+    def __init__(
+        self,
+        adapter: ChainAdapter,
+        peers: PeerStore,
+        start_height: int = 1,
+        end_height: int = 0,
+    ) -> None:
+        self._adapter = adapter
+        self._peers = peers
+        self._start = start_height
+        self._end = end_height
+
+        # Heights still needing bodies, in ascending order
+        self._pending: List[int] = list(range(start_height, end_height + 1))
+        # Heights currently in-flight: height → _InFlight
+        self._in_flight: Dict[int, _InFlight] = {}
+        # Heights successfully stored
+        self._done: Set[int] = set()
+
+        self._last_log: float = 0.0
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def is_complete(self) -> bool:
+        """True when all blocks in the range have been fetched and validated."""
+        return len(self._done) >= (self._end - self._start + 1)
+
+    def progress(self) -> tuple[int, int]:
+        """Return (done_count, total_count)."""
+        total = max(0, self._end - self._start + 1)
+        return len(self._done), total
+
+    def check_run(self) -> bool:
+        """Advance body sync by one step.  Returns True if work was done."""
+        self._reclaim_stale()
+        self._maybe_log_progress()
+
+        if self.is_complete():
+            return False
+
+        # Choose up to BLOCK_REQUEST_BATCH_SIZE live peers
+        live = self._peers.live().pick_n(BLOCK_REQUEST_BATCH_SIZE)
+        if not live:
+            log.debug("BodySync: no live peers")
+            return False
+
+        headroom = BLOCK_REQUEST_BATCH_SIZE - len(self._in_flight)
+        if headroom <= 0:
+            return True  # already at capacity
+
+        # Identify heights to request: pending and not already in-flight
+        to_request: List[int] = []
+        for h in list(self._pending):
+            if h not in self._in_flight and h not in self._done:
+                to_request.append(h)
+            if len(to_request) >= headroom:
+                break
+
+        if not to_request:
+            return False
+
+        peer_cycle = iter(live * ((len(to_request) // len(live)) + 1))
+        for h in to_request:
+            block_hash = self._adapter.get_block_hash_at_height(h)
+            if block_hash is None:
+                log.debug("BodySync: no header hash for height %d, skipping", h)
+                self._pending.remove(h)
+                self._done.add(h)  # treat as not needed
+                continue
+
+            peer: Peer = next(peer_cycle)
+            peer.request_block(block_hash)
+            self._in_flight[h] = _InFlight(
+                hash_hex=block_hash.hex(),
+                height=h,
+                peer_addr=peer.addr,
+            )
+            log.debug(
+                "BodySync: requested block h=%d hash=%s from %s",
+                h,
+                block_hash.hex()[:12],
+                peer.addr,
+            )
+
+        return bool(to_request)
+
+    def on_block_received(self, block_hash_hex: str) -> None:
+        """Called by the adapter when a Block message is successfully stored.
+
+        Marks the corresponding height as complete and removes it from
+        in-flight tracking.
+        """
+        for h, req in list(self._in_flight.items()):
+            if req.hash_hex == block_hash_hex:
+                del self._in_flight[h]
+                self._done.add(h)
+                if h in self._pending:
+                    self._pending.remove(h)
+                log.debug("BodySync: completed h=%d hash=%s", h, block_hash_hex[:12])
+                return
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _reclaim_stale(self) -> None:
+        """Re-queue requests that have timed out."""
+        now = time.monotonic()
+        stale = [
+            h
+            for h, req in self._in_flight.items()
+            if now - req.requested_at > BLOCK_REQUEST_TIMEOUT_SECS
+        ]
+        for h in stale:
+            req = self._in_flight.pop(h)
+            log.debug(
+                "BodySync: stale request h=%d hash=%s from %s — re-queuing",
+                h,
+                req.hash_hex[:12],
+                req.peer_addr,
+            )
+            # Re-add to front of pending if not already done
+            if h not in self._done and h not in self._pending:
+                self._pending.insert(0, h)
+
+    def _maybe_log_progress(self) -> None:
+        now = time.monotonic()
+        if now - self._last_log < LOG_INTERVAL:
+            return
+        self._last_log = now
+        done, total = self.progress()
+        pct = (done / total * 100) if total > 0 else 0
+        log.info(
+            "BodySync: %d/%d blocks (%.1f%%) in_flight=%d pending=%d",
+            done,
+            total,
+            pct,
+            len(self._in_flight),
+            len(self._pending),
+        )

--- a/mimblewimble/p2p/chain_adapter_impl.py
+++ b/mimblewimble/p2p/chain_adapter_impl.py
@@ -1,0 +1,334 @@
+"""
+mimblewimble/p2p/chain_adapter_impl.py
+
+ConcreteChainAdapter — a fully wired :class:`ChainAdapter` implementation
+that connects the P2P sync layer to an in-memory block database, the block
+validator, and an optional transaction pool.
+
+Usage::
+
+    from mimblewimble.p2p.chain_adapter_impl import ConcreteChainAdapter
+    from mimblewimble.genesis import genesis_block_header
+
+    adapter = ConcreteChainAdapter(genesis_hash=genesis_block_header().getHash())
+    peer_store = PeerStore()
+    runner = SyncRunner(adapter, peer_store, txhashset, data_dir)
+
+Reference: servers/src/grin/sync/syncer.rs (ChainAdapter trait impl)
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from io import BytesIO
+from typing import List, Optional
+
+from mimblewimble.blockchain import (
+    BlockHeader,
+    FullBlock,
+    HeaderValidationError,
+    BlockValidationError,
+    validate_header,
+)
+from mimblewimble.p2p.adapter import ChainAdapter
+from mimblewimble.p2p.peers import BlockRecord, HeaderRecord, OutputRecord
+from mimblewimble.pool import TxPool, TxValidationError
+from mimblewimble.pow.blockdb import IBlockDB, InMemoryBlockDB
+from mimblewimble.serializer import Serializer
+
+log = logging.getLogger(__name__)
+
+
+class ConcreteChainAdapter(ChainAdapter):
+    """ChainAdapter backed by an :class:`InMemoryBlockDB`.
+
+    Thread-safe for concurrent peer receive loops.
+
+    Args:
+        genesis_hash:    The 32-byte genesis block hash expected from peers.
+        block_db:        Optional pre-populated block database.  A fresh
+                         :class:`InMemoryBlockDB` is created when omitted.
+        validate_blocks: If True (default), call :meth:`FullBlock.validate`
+                         on every received block.  Disable only in tests.
+    """
+
+    def __init__(
+        self,
+        genesis_hash: bytes,
+        block_db: Optional[IBlockDB] = None,
+        validate_blocks: bool = True,
+    ) -> None:
+        self._genesis_hash = genesis_hash
+        self._db: IBlockDB = block_db or InMemoryBlockDB()
+        self._validate_blocks = validate_blocks
+        self._lock = threading.Lock()
+
+        # Simple in-memory stores for full blocks and the UTXO set (basic)
+        self._blocks: dict[str, bytes] = {}  # hash_hex → raw bytes
+        self._best_height: int = 0
+        self._best_total_difficulty: int = 0
+        self._best_hash: Optional[bytes] = None
+
+        # Transaction pool (Dandelion++ stem/fluff)
+        self._pool: TxPool = TxPool()
+
+    # ------------------------------------------------------------------
+    # ChainAdapter — read-only queries
+    # ------------------------------------------------------------------
+
+    def genesis_hash(self) -> bytes:
+        return self._genesis_hash
+
+    def total_difficulty(self) -> int:
+        with self._lock:
+            return self._best_total_difficulty
+
+    def best_height(self) -> int:
+        with self._lock:
+            return self._best_height
+
+    def get_locator(self) -> List[bytes]:
+        """Return an exponential step-back locator from the current best tip.
+
+        Produces up to 20 hashes stepping back by powers of 2: heights
+        h, h-1, h-2, h-4, h-8, …, 0.
+        """
+        with self._lock:
+            height = self._best_height
+            if height == 0:
+                return [self._genesis_hash]
+
+        hashes: List[bytes] = []
+        step = 1
+        h = height
+        while h >= 0 and len(hashes) < 20:
+            header = self._db.get_header_by_height(h)
+            if header is not None:
+                hashes.append(header.getHash())
+            else:
+                hashes.append(b"\x00" * 32)
+            if h == 0:
+                break
+            h = max(0, h - step)
+            step *= 2
+
+        if not hashes:
+            hashes.append(self._genesis_hash)
+        return hashes
+
+    def get_block_hash_at_height(self, height: int) -> Optional[bytes]:
+        header = self._db.get_header_by_height(height)
+        if header is None:
+            return None
+        return header.getHash()
+
+    # ------------------------------------------------------------------
+    # Header sync
+    # ------------------------------------------------------------------
+
+    def sync_block_headers(self, raw_headers: List[bytes]) -> None:
+        """Validate and store a batch of serialised block headers.
+
+        Invalid headers are skipped with a warning; the rest are applied.
+        Duplicate headers (already stored) are silently ignored.
+        """
+        accepted = 0
+        for raw in raw_headers:
+            try:
+                s = Serializer(BytesIO(raw))
+                header = BlockHeader.deserialize(s)
+            except Exception as exc:
+                log.warning("Failed to deserialise header: %s", exc)
+                continue
+
+            hash_hex = header.getHash().hex()
+            existing = self._db.get_block_header(hash_hex)
+            if existing is not None:
+                continue  # already have this header
+
+            # Chain-link validation against the previous header
+            prev_header = self._db.get_block_header(header.getPreviousHash().hex())
+
+            try:
+                validate_header(header, prev_header=prev_header, block_db=self._db)
+            except HeaderValidationError as exc:
+                log.warning(
+                    "Rejecting header h=%d hash=%s: %s",
+                    header.getHeight(),
+                    hash_hex[:12],
+                    exc,
+                )
+                continue
+
+            self._db.add_header(header)
+            with self._lock:
+                if header.getTotalDifficulty() > self._best_total_difficulty:
+                    self._best_total_difficulty = header.getTotalDifficulty()
+                    self._best_height = header.getHeight()
+                    self._best_hash = header.getHash()
+            accepted += 1
+
+        if accepted:
+            log.debug(
+                "sync_block_headers: accepted %d/%d headers", accepted, len(raw_headers)
+            )
+
+    # ------------------------------------------------------------------
+    # TxHashSet snapshot
+    # ------------------------------------------------------------------
+
+    def txhashset_write(
+        self,
+        block_hash: bytes,
+        height: int,
+        zip_bytes: bytes,
+    ) -> bool:
+        """Stub — full TxHashSet zip application is handled by StateSync."""
+        log.debug(
+            "txhashset_write: hash=%s height=%d size=%d",
+            block_hash.hex()[:12],
+            height,
+            len(zip_bytes),
+        )
+        return True
+
+    # ------------------------------------------------------------------
+    # PIBD segments  (delegated to the TxHashSet / Desegmenter layer)
+    # ------------------------------------------------------------------
+
+    def receive_bitmap_segment(self, block_hash: bytes, segment) -> None:
+        pass
+
+    def receive_output_segment(self, block_hash: bytes, segment) -> None:
+        pass
+
+    def receive_rangeproof_segment(self, block_hash: bytes, segment) -> None:
+        pass
+
+    def receive_kernel_segment(self, block_hash: bytes, segment) -> None:
+        pass
+
+    # ------------------------------------------------------------------
+    # Block sync
+    # ------------------------------------------------------------------
+
+    def handle_block(self, block_hash: bytes, raw_block: bytes) -> bool:
+        """Deserialise, optionally validate, and store a full block.
+
+        Returns True if newly accepted; False if already known.
+        """
+        try:
+            s = Serializer(BytesIO(raw_block))
+            block = FullBlock.deserialize(s)
+        except Exception as exc:
+            log.warning("handle_block: failed to deserialise: %s", exc)
+            return False
+
+        hash_hex = block.getHash().hex()
+        with self._lock:
+            if hash_hex in self._blocks:
+                return False  # duplicate
+
+        if self._validate_blocks:
+            prev_header = self._db.get_block_header(block.getPreviousHash().hex())
+            try:
+                block.validate(prev_header=prev_header, block_db=self._db)
+            except (HeaderValidationError, BlockValidationError) as exc:
+                log.warning(
+                    "handle_block: rejected h=%d hash=%s: %s",
+                    block.getHeight(),
+                    hash_hex[:12],
+                    exc,
+                )
+                return False
+
+        with self._lock:
+            self._blocks[hash_hex] = raw_block
+            if block.getTotalDifficulty() > self._best_total_difficulty:
+                self._best_total_difficulty = block.getTotalDifficulty()
+                self._best_height = block.getHeight()
+                self._best_hash = block.getHash()
+
+        log.debug(
+            "handle_block: accepted h=%d hash=%s", block.getHeight(), hash_hex[:12]
+        )
+        return True
+
+    # ------------------------------------------------------------------
+    # Transaction pool
+    # ------------------------------------------------------------------
+
+    def handle_transaction(self, raw_tx: bytes, from_stem: bool = False) -> bool:
+        """Validate and add a transaction to the mempool."""
+        try:
+            return self._pool.add_transaction(raw_tx, from_stem=from_stem)
+        except TxValidationError as exc:
+            log.warning("handle_transaction: validation failed: %s", exc)
+            return False
+
+    def handle_compact_block(self, raw_compact_block: bytes) -> bool:
+        """Attempt to reconstruct a full block from a compact block.
+
+        Current implementation: if the compact block carries full outputs and
+        kernels (i.e., no short-IDs that need mempool lookup), reconstruct the
+        FullBlock directly.  Otherwise fall back to issuing a GetBlock request
+        (requires the caller to have a reference to the relevant peer).
+        """
+        from mimblewimble.blockchain import BlockHeader
+        from mimblewimble.serializer import Serializer
+        from io import BytesIO
+
+        try:
+            s = Serializer(BytesIO(raw_compact_block))
+            header = BlockHeader.deserialize(s)
+            # Read nonce and counts
+            nonce = int.from_bytes(s.read(8), "big")
+            num_outputs = int.from_bytes(s.read(2), "big")
+            num_kernels = int.from_bytes(s.read(2), "big")
+            num_short_ids = int.from_bytes(s.read(2), "big")
+        except Exception as exc:
+            log.warning("handle_compact_block: deserialise error: %s", exc)
+            return False
+
+        if num_short_ids > 0:
+            # Need mempool short-ID matching — not yet implemented
+            log.debug(
+                "handle_compact_block: %d short-IDs unresolved at h=%d, "
+                "needs GetBlock fallback",
+                num_short_ids,
+                header.getHeight(),
+            )
+            return False
+
+        # All transactions are included as full outputs/kernels — reconstruct block
+        try:
+            from mimblewimble.models.transaction import (
+                TransactionOutput,
+                TransactionKernel,
+                TransactionBody,
+            )
+
+            outputs = [TransactionOutput.deserialize(s) for _ in range(num_outputs)]
+            kernels = [TransactionKernel.deserialize(s) for _ in range(num_kernels)]
+            body = TransactionBody([], outputs, kernels)
+            from mimblewimble.blockchain import FullBlock
+
+            block = FullBlock(header, body)
+        except Exception as exc:
+            log.warning("handle_compact_block: reconstruct error: %s", exc)
+            return False
+
+        return self.handle_block(block.getHash(), block.serialize())
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def get_block_db(self) -> IBlockDB:
+        """Return the underlying block database (useful for testing)."""
+        return self._db
+
+    def get_raw_block(self, hash_hex: str) -> Optional[bytes]:
+        with self._lock:
+            return self._blocks.get(hash_hex)

--- a/mimblewimble/p2p/chain_adapter_impl.py
+++ b/mimblewimble/p2p/chain_adapter_impl.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 
 import logging
 import threading
-from typing import Callable, List, Optional
+from typing import BinaryIO, Callable, List, Optional
 
 from mimblewimble.blockchain import (
     BlockHeader,
@@ -200,6 +200,22 @@ class ConcreteChainAdapter(ChainAdapter):
             block_hash.hex()[:12],
             height,
             len(zip_bytes),
+        )
+        return True
+
+    def txhashset_write_stream(
+        self,
+        block_hash: bytes,
+        height: int,
+        archive: BinaryIO,
+        size: int,
+    ) -> bool:
+        """Accept streamed archive metadata without copying it into memory."""
+        log.debug(
+            "txhashset_write_stream: hash=%s height=%d size=%d",
+            block_hash.hex()[:12],
+            height,
+            size,
         )
         return True
 

--- a/mimblewimble/p2p/chain_adapter_impl.py
+++ b/mimblewimble/p2p/chain_adapter_impl.py
@@ -21,8 +21,7 @@ from __future__ import annotations
 
 import logging
 import threading
-from io import BytesIO
-from typing import List, Optional
+from typing import Callable, List, Optional
 
 from mimblewimble.blockchain import (
     BlockHeader,
@@ -36,6 +35,7 @@ from mimblewimble.p2p.peers import BlockRecord, HeaderRecord, OutputRecord
 from mimblewimble.pool import TxPool, TxValidationError
 from mimblewimble.pow.blockdb import IBlockDB, InMemoryBlockDB
 from mimblewimble.serializer import Serializer
+from mimblewimble.mmr.segment import SegmentType
 
 log = logging.getLogger(__name__)
 
@@ -72,6 +72,15 @@ class ConcreteChainAdapter(ChainAdapter):
 
         # Transaction pool (Dandelion++ stem/fluff)
         self._pool: TxPool = TxPool()
+        self._pibd_segment_handler: Optional[
+            Callable[[SegmentType, bytes, object], None]
+        ] = None
+
+        best_header = self._db.get_best_header()
+        if best_header is not None:
+            self._best_height = best_header.getHeight()
+            self._best_total_difficulty = best_header.getTotalDifficulty()
+            self._best_hash = best_header.getHash()
 
     # ------------------------------------------------------------------
     # ChainAdapter — read-only queries
@@ -136,7 +145,8 @@ class ConcreteChainAdapter(ChainAdapter):
         accepted = 0
         for raw in raw_headers:
             try:
-                s = Serializer(BytesIO(raw))
+                s = Serializer()
+                s.write(raw)
                 header = BlockHeader.deserialize(s)
             except Exception as exc:
                 log.warning("Failed to deserialise header: %s", exc)
@@ -197,17 +207,35 @@ class ConcreteChainAdapter(ChainAdapter):
     # PIBD segments  (delegated to the TxHashSet / Desegmenter layer)
     # ------------------------------------------------------------------
 
+    def set_pibd_segment_handler(
+        self, handler: Optional[Callable[[SegmentType, bytes, object], None]]
+    ) -> None:
+        with self._lock:
+            self._pibd_segment_handler = handler
+
+    def _receive_pibd_segment(
+        self, segment_type: SegmentType, block_hash: bytes, segment: object
+    ) -> None:
+        with self._lock:
+            handler = self._pibd_segment_handler
+        if handler is None:
+            log.debug(
+                "Dropping %s segment without an active StateSync", segment_type.name
+            )
+            return
+        handler(segment_type, block_hash, segment)
+
     def receive_bitmap_segment(self, block_hash: bytes, segment) -> None:
-        pass
+        self._receive_pibd_segment(SegmentType.BITMAP, block_hash, segment)
 
     def receive_output_segment(self, block_hash: bytes, segment) -> None:
-        pass
+        self._receive_pibd_segment(SegmentType.OUTPUT, block_hash, segment)
 
     def receive_rangeproof_segment(self, block_hash: bytes, segment) -> None:
-        pass
+        self._receive_pibd_segment(SegmentType.RANGEPROOF, block_hash, segment)
 
     def receive_kernel_segment(self, block_hash: bytes, segment) -> None:
-        pass
+        self._receive_pibd_segment(SegmentType.KERNEL, block_hash, segment)
 
     # ------------------------------------------------------------------
     # Block sync
@@ -219,7 +247,8 @@ class ConcreteChainAdapter(ChainAdapter):
         Returns True if newly accepted; False if already known.
         """
         try:
-            s = Serializer(BytesIO(raw_block))
+            s = Serializer()
+            s.write(raw_block)
             block = FullBlock.deserialize(s)
         except Exception as exc:
             log.warning("handle_block: failed to deserialise: %s", exc)
@@ -277,10 +306,10 @@ class ConcreteChainAdapter(ChainAdapter):
         """
         from mimblewimble.blockchain import BlockHeader
         from mimblewimble.serializer import Serializer
-        from io import BytesIO
 
         try:
-            s = Serializer(BytesIO(raw_compact_block))
+            s = Serializer()
+            s.write(raw_compact_block)
             header = BlockHeader.deserialize(s)
             # Read nonce and counts
             nonce = int.from_bytes(s.read(8), "big")

--- a/mimblewimble/p2p/chain_adapter_impl.py
+++ b/mimblewimble/p2p/chain_adapter_impl.py
@@ -75,6 +75,9 @@ class ConcreteChainAdapter(ChainAdapter):
         self._pibd_segment_handler: Optional[
             Callable[[SegmentType, bytes, object], None]
         ] = None
+        self._txhashset_stream_handler: Optional[
+            Callable[[bytes, int, BinaryIO, int], bool]
+        ] = None
 
         best_header = self._db.get_best_header()
         if best_header is not None:
@@ -210,7 +213,11 @@ class ConcreteChainAdapter(ChainAdapter):
         archive: BinaryIO,
         size: int,
     ) -> bool:
-        """Accept streamed archive metadata without copying it into memory."""
+        """Forward a streamed archive to the active StateSync consumer."""
+        with self._lock:
+            handler = self._txhashset_stream_handler
+        if handler is not None:
+            return handler(block_hash, height, archive, size)
         log.debug(
             "txhashset_write_stream: hash=%s height=%d size=%d",
             block_hash.hex()[:12],
@@ -218,6 +225,12 @@ class ConcreteChainAdapter(ChainAdapter):
             size,
         )
         return True
+
+    def set_txhashset_stream_handler(
+        self, handler: Optional[Callable[[bytes, int, BinaryIO, int], bool]]
+    ) -> None:
+        with self._lock:
+            self._txhashset_stream_handler = handler
 
     # ------------------------------------------------------------------
     # PIBD segments  (delegated to the TxHashSet / Desegmenter layer)

--- a/mimblewimble/p2p/chain_adapter_impl.py
+++ b/mimblewimble/p2p/chain_adapter_impl.py
@@ -78,6 +78,7 @@ class ConcreteChainAdapter(ChainAdapter):
         self._txhashset_stream_handler: Optional[
             Callable[[bytes, int, BinaryIO, int], bool]
         ] = None
+        self._body_sync_handler: Optional[Callable[[str], None]] = None
 
         best_header = self._db.get_best_header()
         if best_header is not None:
@@ -232,6 +233,10 @@ class ConcreteChainAdapter(ChainAdapter):
         with self._lock:
             self._txhashset_stream_handler = handler
 
+    def set_body_sync_handler(self, handler: Optional[Callable[[str], None]]) -> None:
+        with self._lock:
+            self._body_sync_handler = handler
+
     # ------------------------------------------------------------------
     # PIBD segments  (delegated to the TxHashSet / Desegmenter layer)
     # ------------------------------------------------------------------
@@ -311,6 +316,10 @@ class ConcreteChainAdapter(ChainAdapter):
         log.debug(
             "handle_block: accepted h=%d hash=%s", block.getHeight(), hash_hex[:12]
         )
+        with self._lock:
+            body_sync_handler = self._body_sync_handler
+        if body_sync_handler is not None:
+            body_sync_handler(hash_hex)
         return True
 
     # ------------------------------------------------------------------

--- a/mimblewimble/p2p/connection.py
+++ b/mimblewimble/p2p/connection.py
@@ -15,7 +15,7 @@ import errno
 import logging
 import socket
 import struct
-from typing import Optional, Tuple
+from typing import BinaryIO, Optional, Tuple
 
 from mimblewimble.p2p.message import (
     HEADER_LEN,
@@ -28,6 +28,8 @@ log = logging.getLogger(__name__)
 
 # Maximum allowed body size (32 MiB) — prevent memory exhaustion
 MAX_BODY_BYTES: int = 32 * 1024 * 1024
+# Maximum TxHashSet archive attachment size accepted by the streaming path.
+MAX_ATTACHMENT_BYTES: int = 2 * 1024 * 1024 * 1024
 
 # Default connect / IO timeout in seconds
 DEFAULT_TIMEOUT: float = 30.0
@@ -134,6 +136,62 @@ class Connection:
         )
         return msg_type, bytes(body)
 
+    def recv_message_with_attachment(self) -> Tuple[MessageType, bytes, bytes]:
+        """Receive a message and its TxHashSet archive attachment, if present.
+
+        Grin sends ``TxHashSetArchive`` metadata in the framed message body,
+        followed immediately by the declared archive bytes outside that frame.
+        Reading both together prevents the attachment from being mistaken for
+        the next P2P frame.
+        """
+        msg_type, body = self.recv_message()
+        if msg_type != MessageType.TxHashSetArchive:
+            return msg_type, body, b""
+        if len(body) != 48:
+            raise ConnectionError(
+                f"Invalid TxHashSetArchive metadata length: {len(body)}"
+            )
+
+        attachment_len = struct.unpack_from(">Q", body, 40)[0]
+        if attachment_len > MAX_ATTACHMENT_BYTES:
+            raise ConnectionError(
+                f"Attachment too large: {attachment_len} > {MAX_ATTACHMENT_BYTES}"
+            )
+        return msg_type, body, bytes(self._recv_exactly(attachment_len))
+
+    def recv_message_with_attachment_to(
+        self, sink: BinaryIO, chunk_size: int = 64 * 1024
+    ) -> Tuple[MessageType, bytes, int]:
+        """Receive a message and stream its archive attachment into *sink*.
+
+        Returns the message type, framed body, and number of attachment bytes
+        written. Non-archive messages return an attachment size of zero.
+        """
+        msg_type, body = self.recv_message()
+        if msg_type != MessageType.TxHashSetArchive:
+            return msg_type, body, 0
+        if len(body) != 48:
+            raise ConnectionError(
+                f"Invalid TxHashSetArchive metadata length: {len(body)}"
+            )
+
+        attachment_len = struct.unpack_from(">Q", body, 40)[0]
+        if attachment_len > MAX_ATTACHMENT_BYTES:
+            raise ConnectionError(
+                f"Attachment too large: {attachment_len} > {MAX_ATTACHMENT_BYTES}"
+            )
+        if chunk_size <= 0:
+            raise ValueError("chunk_size must be positive")
+
+        remaining = attachment_len
+        written = 0
+        while remaining:
+            chunk = self._recv_chunk(min(chunk_size, remaining))
+            sink.write(chunk)
+            written += len(chunk)
+            remaining -= len(chunk)
+        return msg_type, body, written
+
     def recv_message_nonblocking(self) -> Optional[Tuple[MessageType, bytes]]:
         """Return a message if one is buffered; otherwise return None.
 
@@ -219,6 +277,23 @@ class Connection:
                 raise ConnectionError("Peer closed connection unexpectedly")
             result.extend(chunk)
         return result
+
+    def _recv_chunk(self, n: int) -> bytes:
+        """Read up to *n* bytes, consuming buffered data first."""
+        if self._buf:
+            take = min(n, len(self._buf))
+            chunk = bytes(self._buf[:take])
+            del self._buf[:take]
+            return chunk
+        try:
+            chunk = self._sock.recv(n)
+        except OSError as e:
+            self.closed = True
+            raise ConnectionError(f"Recv failed: {e}") from e
+        if not chunk:
+            self.closed = True
+            raise ConnectionError("Peer closed connection unexpectedly")
+        return chunk
 
     def __repr__(self) -> str:
         return f"Connection(peer={self.peer_addr!r}, closed={self.closed})"

--- a/mimblewimble/p2p/handshake.py
+++ b/mimblewimble/p2p/handshake.py
@@ -130,7 +130,7 @@ def do_handshake_outbound(
         user_agent=shake.user_agent,
         genesis_hash=shake.genesis_hash,
         peer_addr=conn.peer_addr,
-        nonce=shake.nonce,
+        nonce=nonce,
     )
 
 
@@ -167,9 +167,7 @@ def do_handshake_inbound(
     shake = MsgShake(
         version=PROTOCOL_VERSION,
         capabilities=int(Capabilities.FULL_NODE),
-        nonce=nonce,
         genesis_block_difficulty=total_difficulty,
-        receiver_addr=hand.sender_addr,
         user_agent=USER_AGENT,
         genesis_hash=genesis_hash,
     )

--- a/mimblewimble/p2p/message.py
+++ b/mimblewimble/p2p/message.py
@@ -745,3 +745,41 @@ class MsgKernelSegment:
     def deserialize(cls, body: bytes) -> "MsgKernelSegment":
         block_hash, segment = _parse_segment_response(body)
         return cls(block_hash=block_hash, segment=segment)
+
+
+# ---------------------------------------------------------------------------
+# Compact block
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class MsgCompactBlock:
+    """A compact block sent in response to ``GetCompactBlock``.
+
+    Wire body (all LE):
+        [BlockHeader bytes]
+        8  bytes  nonce            uint64
+        2  bytes  num_full_outputs uint16
+        2  bytes  num_full_kernels uint16
+        2  bytes  num_short_ids    uint16
+        [full output bytes] * num_full_outputs
+        [full kernel bytes] * num_full_kernels
+        [6-byte short-id]  * num_short_ids
+
+    Note: Full output/kernel parsing requires the serializer layer from
+    ``mimblewimble.blockchain`` and is therefore done lazily on access.
+    """
+
+    msg_type = MessageType.CompactBlock
+    # Raw body bytes — header + nonce + short-IDs; parsed on demand.
+    raw_body: bytes = field(default_factory=bytes)
+    block_hash: bytes = field(default_factory=lambda: b"\x00" * 32)
+
+    def serialize(self) -> bytes:
+        return pack_header(self.msg_type, self.raw_body)
+
+    @classmethod
+    def deserialize(cls, body: bytes) -> "MsgCompactBlock":
+        # The block hash is not transmitted separately; callers should compute
+        # it from the header inside raw_body if needed.
+        return cls(raw_body=body, block_hash=b"\x00" * 32)

--- a/mimblewimble/p2p/message.py
+++ b/mimblewimble/p2p/message.py
@@ -5,11 +5,11 @@ Grin P2P wire protocol message types and serialisation.
 
 Message frame:
     2 bytes  magic          [0x61, 0x3d] on mainnet
-    4 bytes  msg_type       LE uint32 (MessageType enum value)
-    8 bytes  body_len       LE uint64
+    1 byte   msg_type       uint8 (MessageType enum value)
+    8 bytes  body_len       BE uint64
 
-All integers are little-endian unless noted.  Strings are 4-byte LE
-length-prefixed UTF-8.
+Message bodies in this module use Grin's big-endian serialization. Variable-length
+byte strings have a u64 big-endian length prefix.
 
 Reference: p2p/src/msg.rs in the Grin repository.
 """
@@ -19,6 +19,7 @@ from __future__ import annotations
 import struct
 from dataclasses import dataclass, field
 from enum import IntEnum
+from ipaddress import ip_address
 from typing import List, Optional, Tuple
 
 from mimblewimble.mmr.segment import (
@@ -34,10 +35,11 @@ from mimblewimble.mmr.segment import (
 
 MAINNET_MAGIC: bytes = bytes([0x61, 0x3D])
 TESTNET_MAGIC: bytes = bytes([0x83, 0xC1])
-HEADER_LEN: int = 2 + 4 + 8  # magic(2) + type(4) + body_len(8)
+HEADER_LEN: int = 2 + 1 + 8  # magic(2) + type(1) + body_len(8)
 
-# Current protocol version advertised in Hand/Shake
-PROTOCOL_VERSION: int = 1
+# Current protocol version advertised in Hand/Shake.
+# Matches Grin core's ``global::PROTOCOL_VERSION``.
+PROTOCOL_VERSION: int = 1000
 
 # User-agent string
 USER_AGENT: str = "MW/mimblewimble-py/0.1.0"
@@ -65,28 +67,27 @@ class MessageType(IntEnum):
     GetPeerAddrs = 5
     PeerAddrs = 6
     GetHeaders = 7
-    Headers = 8
-    GetBlock = 9
-    Block = 10
-    GetCompactBlock = 11
-    CompactBlock = 12
-    StemTransaction = 13
-    Transaction = 14
-    TxHashSetRequest = 15
-    TxHashSetArchive = 16
-    BanReason = 17
-    GetTransactionKernel = 18
-    TransactionKernel = 19
-    KernelDataRequest = 20
-    KernelDataResponse = 21
-    GetOutputBitmapSegment = 22
-    OutputBitmapSegment = 23
-    GetOutputSegment = 24
-    OutputSegment = 25
-    GetRangeProofSegment = 26
-    RangeProofSegment = 27
-    GetKernelSegment = 28
-    KernelSegment = 29
+    Header = 8
+    Headers = 9
+    GetBlock = 10
+    Block = 11
+    GetCompactBlock = 12
+    CompactBlock = 13
+    StemTransaction = 14
+    Transaction = 15
+    TxHashSetRequest = 16
+    TxHashSetArchive = 17
+    BanReason = 18
+    GetTransaction = 19
+    TransactionKernel = 20
+    GetOutputBitmapSegment = 21
+    OutputBitmapSegment = 22
+    GetOutputSegment = 23
+    OutputSegment = 24
+    GetRangeProofSegment = 25
+    RangeProofSegment = 26
+    GetKernelSegment = 27
+    KernelSegment = 28
 
 
 # ---------------------------------------------------------------------------
@@ -97,12 +98,12 @@ class MessageType(IntEnum):
 def pack_header(
     msg_type: MessageType, body: bytes, magic: bytes = MAINNET_MAGIC
 ) -> bytes:
-    """Prepend the 14-byte frame header to *body*."""
-    return magic + struct.pack("<IQ", int(msg_type), len(body)) + body
+    """Prepend the 11-byte frame header to *body*."""
+    return magic + struct.pack(">BQ", int(msg_type), len(body)) + body
 
 
 def unpack_header(data: bytes) -> Tuple[bytes, MessageType, int]:
-    """Parse the 14-byte frame header.
+    """Parse the 11-byte frame header.
 
     Returns:
         (magic, msg_type, body_len)
@@ -112,7 +113,7 @@ def unpack_header(data: bytes) -> Tuple[bytes, MessageType, int]:
     if len(data) < HEADER_LEN:
         raise ValueError(f"Header too short: {len(data)} < {HEADER_LEN}")
     magic = data[:2]
-    msg_type, body_len = struct.unpack_from("<IQ", data, 2)
+    msg_type, body_len = struct.unpack_from(">BQ", data, 2)
     return magic, MessageType(msg_type), body_len
 
 
@@ -123,23 +124,33 @@ def unpack_header(data: bytes) -> Tuple[bytes, MessageType, int]:
 
 def _encode_str(s: str) -> bytes:
     encoded = s.encode("utf-8")
-    return struct.pack("<I", len(encoded)) + encoded
+    return _encode_len_prefixed_bytes(encoded)
 
 
 def _decode_str(data: bytes, offset: int) -> Tuple[str, int]:
-    (length,) = struct.unpack_from("<I", data, offset)
-    offset += 4
-    return data[offset : offset + length].decode("utf-8"), offset + length
+    value, offset = _decode_len_prefixed_bytes(data, offset)
+    return value.decode("utf-8"), offset
 
 
 def _encode_bytes(b: bytes) -> bytes:
-    return struct.pack("<I", len(b)) + b
+    return _encode_len_prefixed_bytes(b)
 
 
 def _decode_bytes(data: bytes, offset: int) -> Tuple[bytes, int]:
-    (length,) = struct.unpack_from("<I", data, offset)
-    offset += 4
-    return data[offset : offset + length], offset + length
+    return _decode_len_prefixed_bytes(data, offset)
+
+
+def _encode_len_prefixed_bytes(value: bytes) -> bytes:
+    return struct.pack(">Q", len(value)) + value
+
+
+def _decode_len_prefixed_bytes(data: bytes, offset: int) -> Tuple[bytes, int]:
+    (length,) = struct.unpack_from(">Q", data, offset)
+    offset += 8
+    end = offset + length
+    if len(data) < end:
+        raise ValueError("Length-prefixed bytes are truncated")
+    return data[offset:end], end
 
 
 # ---------------------------------------------------------------------------
@@ -154,12 +165,28 @@ class PeerAddr:
     addr: str  # "host:port"
 
     def serialize(self) -> bytes:
-        return _encode_str(self.addr)
+        host, port_text = self.addr.rsplit(":", 1)
+        address = ip_address(host.strip("[]"))
+        if address.version == 4:
+            return b"\x00" + address.packed + struct.pack(">H", int(port_text))
+        return b"\x01" + address.packed + struct.pack(">H", int(port_text))
 
     @classmethod
     def deserialize(cls, data: bytes, offset: int = 0) -> Tuple["PeerAddr", int]:
-        addr, offset = _decode_str(data, offset)
-        return cls(addr=addr), offset
+        if len(data) <= offset:
+            raise ValueError("Peer address is missing its IP family")
+        family = data[offset]
+        offset += 1
+        address_length = 4 if family == 0 else 16
+        end = offset + address_length + 2
+        if len(data) < end:
+            raise ValueError("Peer address is truncated")
+        address = ip_address(data[offset : offset + address_length])
+        port = struct.unpack_from(">H", data, offset + address_length)[0]
+        host = str(address)
+        if address.version == 6:
+            host = f"[{host}]"
+        return cls(addr=f"{host}:{port}"), end
 
 
 # ---------------------------------------------------------------------------
@@ -176,11 +203,18 @@ class Capabilities(IntEnum):
     PEER_LIST = 1 << 2
     TX_KERNEL_HASH = 1 << 3
     PIBD_HIST = 1 << 4
-    PIBD_HIST_1 = 1 << 5
-    PIBD_HIST_2 = 1 << 6
+    BLOCK_HIST = 1 << 5
+    PIBD_HIST_1 = 1 << 6
 
     # Convenience alias
-    FULL_NODE = FULL_HIST | TXHASHSET_HIST | PEER_LIST | TX_KERNEL_HASH | PIBD_HIST
+    FULL_NODE = (
+        FULL_HIST
+        | TXHASHSET_HIST
+        | PEER_LIST
+        | TX_KERNEL_HASH
+        | PIBD_HIST
+        | PIBD_HIST_1
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -208,14 +242,14 @@ class MsgError:
 class MsgHand:
     """Hand — initial handshake message sent by the connecting peer.
 
-    Wire body (all LE):
+    Wire body (all big-endian):
         4   version       uint32  protocol version
         4   capabilities  uint32  bitmask
         8   nonce         uint64  random nonce to detect self-connections
-        8   genesis_block_difficulty uint64
-        N   sender_addr   length-prefixed string "host:port"
-        N   receiver_addr length-prefixed string "host:port"
-        N   user_agent    length-prefixed string
+        8   total_difficulty uint64
+        7/19 sender_addr   PeerAddr
+        7/19 receiver_addr PeerAddr
+        N   user_agent    u64 length-prefixed UTF-8
         32  genesis_hash  bytes
     """
 
@@ -224,42 +258,43 @@ class MsgHand:
     capabilities: int = int(Capabilities.FULL_NODE)
     nonce: int = 0
     genesis_block_difficulty: int = 0
-    sender_addr: str = ""
-    receiver_addr: str = ""
+    sender_addr: str = "0.0.0.0:0"
+    receiver_addr: str = "0.0.0.0:0"
     user_agent: str = USER_AGENT
     genesis_hash: bytes = field(default_factory=lambda: b"\x00" * 32)
 
     def serialize(self) -> bytes:
         body = struct.pack(
-            "<IIQQ",
+            ">IIQQ",
             self.version,
             self.capabilities,
             self.nonce,
             self.genesis_block_difficulty,
         )
-        body += _encode_str(self.sender_addr)
-        body += _encode_str(self.receiver_addr)
-        body += _encode_str(self.user_agent)
+        body += PeerAddr(self.sender_addr).serialize()
+        body += PeerAddr(self.receiver_addr).serialize()
+        body += _encode_len_prefixed_bytes(self.user_agent.encode("utf-8"))
         body += self.genesis_hash[:32].ljust(32, b"\x00")
         return pack_header(self.msg_type, body)
 
     @classmethod
     def deserialize(cls, body: bytes) -> "MsgHand":
         version, capabilities, nonce, genesis_block_difficulty = struct.unpack_from(
-            "<IIQQ", body, 0
+            ">IIQQ", body, 0
         )
         offset = 4 + 4 + 8 + 8
-        sender_addr, offset = _decode_str(body, offset)
-        receiver_addr, offset = _decode_str(body, offset)
-        user_agent, offset = _decode_str(body, offset)
+        sender, offset = PeerAddr.deserialize(body, offset)
+        receiver, offset = PeerAddr.deserialize(body, offset)
+        user_agent_bytes, offset = _decode_len_prefixed_bytes(body, offset)
+        user_agent = user_agent_bytes.decode("utf-8")
         genesis_hash = body[offset : offset + 32]
         return cls(
             version=version,
             capabilities=capabilities,
             nonce=nonce,
             genesis_block_difficulty=genesis_block_difficulty,
-            sender_addr=sender_addr,
-            receiver_addr=receiver_addr,
+            sender_addr=sender.addr,
+            receiver_addr=receiver.addr,
             user_agent=user_agent,
             genesis_hash=genesis_hash,
         )
@@ -269,46 +304,41 @@ class MsgHand:
 class MsgShake:
     """Shake — handshake response.
 
-    Same wire format as Hand but without sender_addr.
+    Wire body (all big-endian): version, capabilities, total difficulty,
+    user agent, and genesis hash.
     """
 
     msg_type = MessageType.Shake
     version: int = PROTOCOL_VERSION
     capabilities: int = int(Capabilities.FULL_NODE)
-    nonce: int = 0
     genesis_block_difficulty: int = 0
-    receiver_addr: str = ""
     user_agent: str = USER_AGENT
     genesis_hash: bytes = field(default_factory=lambda: b"\x00" * 32)
 
     def serialize(self) -> bytes:
         body = struct.pack(
-            "<IIQQ",
+            ">IIQ",
             self.version,
             self.capabilities,
-            self.nonce,
             self.genesis_block_difficulty,
         )
-        body += _encode_str(self.receiver_addr)
-        body += _encode_str(self.user_agent)
+        body += _encode_len_prefixed_bytes(self.user_agent.encode("utf-8"))
         body += self.genesis_hash[:32].ljust(32, b"\x00")
         return pack_header(self.msg_type, body)
 
     @classmethod
     def deserialize(cls, body: bytes) -> "MsgShake":
-        version, capabilities, nonce, genesis_block_difficulty = struct.unpack_from(
-            "<IIQQ", body, 0
+        version, capabilities, genesis_block_difficulty = struct.unpack_from(
+            ">IIQ", body, 0
         )
-        offset = 4 + 4 + 8 + 8
-        receiver_addr, offset = _decode_str(body, offset)
-        user_agent, offset = _decode_str(body, offset)
+        offset = 4 + 4 + 8
+        user_agent_bytes, offset = _decode_len_prefixed_bytes(body, offset)
+        user_agent = user_agent_bytes.decode("utf-8")
         genesis_hash = body[offset : offset + 32]
         return cls(
             version=version,
             capabilities=capabilities,
-            nonce=nonce,
             genesis_block_difficulty=genesis_block_difficulty,
-            receiver_addr=receiver_addr,
             user_agent=user_agent,
             genesis_hash=genesis_hash,
         )
@@ -323,12 +353,12 @@ class MsgPing:
     height: int = 0
 
     def serialize(self) -> bytes:
-        body = struct.pack("<QQ", self.total_difficulty, self.height)
+        body = struct.pack(">QQ", self.total_difficulty, self.height)
         return pack_header(self.msg_type, body)
 
     @classmethod
     def deserialize(cls, body: bytes) -> "MsgPing":
-        total_difficulty, height = struct.unpack_from("<QQ", body)
+        total_difficulty, height = struct.unpack_from(">QQ", body)
         return cls(total_difficulty=total_difficulty, height=height)
 
 
@@ -341,12 +371,12 @@ class MsgPong:
     height: int = 0
 
     def serialize(self) -> bytes:
-        body = struct.pack("<QQ", self.total_difficulty, self.height)
+        body = struct.pack(">QQ", self.total_difficulty, self.height)
         return pack_header(self.msg_type, body)
 
     @classmethod
     def deserialize(cls, body: bytes) -> "MsgPong":
-        total_difficulty, height = struct.unpack_from("<QQ", body)
+        total_difficulty, height = struct.unpack_from(">QQ", body)
         return cls(total_difficulty=total_difficulty, height=height)
 
 
@@ -358,11 +388,11 @@ class MsgGetPeerAddrs:
     capabilities: int = int(Capabilities.FULL_NODE)
 
     def serialize(self) -> bytes:
-        return pack_header(self.msg_type, struct.pack("<I", self.capabilities))
+        return pack_header(self.msg_type, struct.pack(">I", self.capabilities))
 
     @classmethod
     def deserialize(cls, body: bytes) -> "MsgGetPeerAddrs":
-        (capabilities,) = struct.unpack_from("<I", body)
+        (capabilities,) = struct.unpack_from(">I", body)
         return cls(capabilities=capabilities)
 
 
@@ -374,17 +404,19 @@ class MsgPeerAddrs:
     peers: List[PeerAddr] = field(default_factory=list)
 
     def serialize(self) -> bytes:
-        body = struct.pack("<I", len(self.peers))
+        body = struct.pack(">I", len(self.peers))
         for p in self.peers:
             body += p.serialize()
         return pack_header(self.msg_type, body)
 
     @classmethod
     def deserialize(cls, body: bytes) -> "MsgPeerAddrs":
-        (n,) = struct.unpack_from("<I", body)
+        (n,) = struct.unpack_from(">I", body)
+        if n > MAX_PEER_ADDRS:
+            raise ValueError(f"Peer address count exceeds limit: {n}")
         offset = 4
         peers = []
-        for _ in range(min(n, MAX_PEER_ADDRS)):
+        for _ in range(n):
             peer, offset = PeerAddr.deserialize(body, offset)
             peers.append(peer)
         return cls(peers=peers)
@@ -398,15 +430,17 @@ class MsgGetHeaders:
     locator: List[bytes] = field(default_factory=list)
 
     def serialize(self) -> bytes:
-        body = struct.pack("<I", len(self.locator))
+        if len(self.locator) > 255:
+            raise ValueError("Header locator count exceeds wire limit: 255")
+        body = struct.pack(">B", len(self.locator))
         for h in self.locator:
             body += h[:32].ljust(32, b"\x00")
         return pack_header(self.msg_type, body)
 
     @classmethod
     def deserialize(cls, body: bytes) -> "MsgGetHeaders":
-        (n,) = struct.unpack_from("<I", body)
-        offset = 4
+        (n,) = struct.unpack_from(">B", body)
+        offset = 1
         locator = []
         for _ in range(n):
             locator.append(body[offset : offset + 32])
@@ -477,7 +511,7 @@ class MsgTxHashSetRequest:
 
     Wire body:
         32 bytes  block_hash
-        8  bytes  LE height
+        8  bytes  BE height
     """
 
     msg_type = MessageType.TxHashSetRequest
@@ -485,46 +519,53 @@ class MsgTxHashSetRequest:
     height: int = 0
 
     def serialize(self) -> bytes:
-        body = self.block_hash[:32].ljust(32, b"\x00") + struct.pack("<Q", self.height)
+        body = self.block_hash[:32].ljust(32, b"\x00") + struct.pack(">Q", self.height)
         return pack_header(self.msg_type, body)
 
     @classmethod
     def deserialize(cls, body: bytes) -> "MsgTxHashSetRequest":
         block_hash = body[:32]
-        (height,) = struct.unpack_from("<Q", body, 32)
+        (height,) = struct.unpack_from(">Q", body, 32)
         return cls(block_hash=block_hash, height=height)
 
 
 @dataclass
 class MsgTxHashSetArchive:
-    """Response with TxHashSet ZIP bytes (streamed as body bytes).
+    """Response with TxHashSet archive metadata.
 
     Wire body:
         32 bytes  block_hash
-        8  bytes  LE height
-        8  bytes  LE bytes_len  (length of following ZIP bytes)
-        bytes_len bytes  zip data
+        8  bytes  BE height
+        8  bytes  BE bytes_len
+
+    Archive bytes follow the message body as a streamed attachment and are not
+    included in the message frame.
     """
 
     msg_type = MessageType.TxHashSetArchive
     block_hash: bytes = field(default_factory=lambda: b"\x00" * 32)
     height: int = 0
     zip_bytes: bytes = b""
+    bytes_len: Optional[int] = None
 
     def serialize(self) -> bytes:
+        bytes_len = len(self.zip_bytes) if self.bytes_len is None else self.bytes_len
         body = (
             self.block_hash[:32].ljust(32, b"\x00")
-            + struct.pack("<QQ", self.height, len(self.zip_bytes))
-            + self.zip_bytes
+            + struct.pack(">QQ", self.height, bytes_len)
         )
         return pack_header(self.msg_type, body)
 
     @classmethod
     def deserialize(cls, body: bytes) -> "MsgTxHashSetArchive":
         block_hash = body[:32]
-        height, bytes_len = struct.unpack_from("<QQ", body, 32)
-        zip_bytes = body[32 + 16 : 32 + 16 + bytes_len]
-        return cls(block_hash=block_hash, height=height, zip_bytes=zip_bytes)
+        height, bytes_len = struct.unpack_from(">QQ", body, 32)
+        return cls(
+            block_hash=block_hash,
+            height=height,
+            zip_bytes=b"",
+            bytes_len=bytes_len,
+        )
 
 
 @dataclass

--- a/mimblewimble/p2p/message.py
+++ b/mimblewimble/p2p/message.py
@@ -22,12 +22,14 @@ from enum import IntEnum
 from ipaddress import ip_address
 from typing import List, Optional, Tuple
 
+from mimblewimble.blockchain import BlockHeader
 from mimblewimble.mmr.segment import (
     Segment,
     SegmentIdentifier,
     SegmentType,
     SegmentTypeIdentifier,
 )
+from mimblewimble.serializer import Serializer
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -450,28 +452,49 @@ class MsgGetHeaders:
 
 @dataclass
 class MsgHeaders:
-    """Response containing serialised block headers."""
+    """Response containing consecutively serialised block headers.
+
+    Grin encodes a big-endian u16 count followed by each ``BlockHeader``
+    directly, without a per-header length prefix.
+    """
 
     msg_type = MessageType.Headers
     # Each entry is the raw serialised bytes of a BlockHeader
     headers: List[bytes] = field(default_factory=list)
 
     def serialize(self) -> bytes:
-        body = struct.pack("<I", len(self.headers))
+        if len(self.headers) > MAX_HEADERS:
+            raise ValueError(f"Header count exceeds limit: {len(self.headers)}")
+        body = struct.pack(">H", len(self.headers))
         for h in self.headers:
-            body += struct.pack("<I", len(h)) + h
+            body += h
         return pack_header(self.msg_type, body)
 
     @classmethod
     def deserialize(cls, body: bytes) -> "MsgHeaders":
-        (n,) = struct.unpack_from("<I", body)
-        offset = 4
+        if len(body) < 2:
+            raise ValueError("Headers message is missing its count")
+        (n,) = struct.unpack_from(">H", body)
+        if n > MAX_HEADERS:
+            raise ValueError(f"Header count exceeds limit: {n}")
+        payload = body[2:]
+        serializer = Serializer()
+        serializer.write(payload)
         headers = []
-        for _ in range(min(n, MAX_HEADERS)):
-            (hlen,) = struct.unpack_from("<I", body, offset)
-            offset += 4
-            headers.append(body[offset : offset + hlen])
-            offset += hlen
+        for _ in range(n):
+            offset = serializer.pnt
+            try:
+                header = BlockHeader.deserialize(serializer)
+            except (IndexError, ValueError, OverflowError) as exc:
+                raise ValueError("Malformed serialised block header") from exc
+            raw_header = payload[offset : serializer.pnt]
+            check = Serializer()
+            header.serialize(check)
+            if check.getvalue() != raw_header:
+                raise ValueError("Malformed serialised block header")
+            headers.append(raw_header)
+        if serializer.pnt != len(payload):
+            raise ValueError("Headers message contains trailing bytes")
         return cls(headers=headers)
 
 
@@ -666,11 +689,22 @@ def _make_segment_response(
     return pack_header(msg_type, body)
 
 
-def _parse_segment_response(body: bytes) -> Tuple[bytes, Segment]:
+def _parse_segment_response(body: bytes) -> Tuple[bytes, Optional[Segment]]:
     """Parse a XxxSegment response body."""
+    if len(body) < 32:
+        raise ValueError("Segment response is missing its block hash")
     block_hash = body[:32]
+    if len(body) == 32:
+        return block_hash, None
+    if len(body) < 36:
+        raise ValueError("Segment response is missing its segment length")
     (seg_len,) = struct.unpack_from("<I", body, 32)
-    segment = Segment.deserialize(body[36 : 36 + seg_len])
+    end = 36 + seg_len
+    if len(body) < end:
+        raise ValueError("Segment response is truncated")
+    if len(body) > end:
+        raise ValueError("Segment response has trailing bytes")
+    segment = Segment.deserialize(body[36:end]) if seg_len else None
     return block_hash, segment
 
 

--- a/mimblewimble/p2p/peer.py
+++ b/mimblewimble/p2p/peer.py
@@ -20,6 +20,10 @@ from typing import TYPE_CHECKING, Callable, List, Optional
 from mimblewimble.p2p.adapter import ChainAdapter
 from mimblewimble.p2p.connection import Connection, ConnectionError
 from mimblewimble.p2p.handshake import HandshakeResult, do_handshake_outbound
+
+# Maximum number of peer addresses to send in a single PeerAddrs reply
+MAX_PEER_ADDRS_RESPONSE = 20
+
 from mimblewimble.p2p.message import (
     MessageType,
     MsgGetHeaders,
@@ -29,6 +33,9 @@ from mimblewimble.p2p.message import (
     MsgGetKernelSegment,
     MsgGetBlock,
     MsgGetCompactBlock,
+    MsgCompactBlock,
+    MsgGetPeerAddrs,
+    MsgPeerAddrs,
     MsgPing,
     MsgTxHashSetRequest,
     MsgBanReason,
@@ -77,12 +84,14 @@ class Peer:
         handshake: HandshakeResult,
         adapter: Optional[ChainAdapter] = None,
         peer_store: Optional["PeerStore"] = None,
+        on_new_peer_addr: Optional[Callable[[str], None]] = None,
     ) -> None:
         self._conn = conn
         self.handshake = handshake
         self.addr = conn.peer_addr
         self._adapter = adapter
         self._peer_store = peer_store
+        self._on_new_peer_addr = on_new_peer_addr
         self._running = False
         self._thread: Optional[threading.Thread] = None
         self._last_seen: float = time.monotonic()
@@ -168,6 +177,32 @@ class Peer:
         msg = MsgGetKernelSegment(block_hash=block_hash, identifier=identifier)
         self._send(msg.serialize())
 
+    def request_block(self, block_hash: bytes) -> None:
+        """Send a GetBlock request for *block_hash*."""
+        msg = MsgGetBlock(block_hash=block_hash)
+        self._send(msg.serialize())
+
+    def request_compact_block(self, block_hash: bytes) -> None:
+        """Send a GetCompactBlock request for *block_hash*."""
+        msg = MsgGetCompactBlock(block_hash=block_hash)
+        self._send(msg.serialize())
+
+    def request_peer_addrs(self) -> None:
+        """Send a GetPeerAddrs request to learn about more peers."""
+        from mimblewimble.p2p.message import Capabilities
+
+        msg = MsgGetPeerAddrs(capabilities=int(Capabilities.FULL_NODE))
+        self._send(msg.serialize())
+
+    def send_peer_addrs(self, peer_addrs) -> None:
+        """Reply with a list of known peer addresses.
+
+        Args:
+            peer_addrs: List of :class:`~mimblewimble.p2p.message.PeerAddr`.
+        """
+        msg = MsgPeerAddrs(peers=peer_addrs)
+        self._send(msg.serialize())
+
     def ban(self, reason: str = "") -> None:
         """Send a BanReason and close the connection."""
         try:
@@ -244,9 +279,31 @@ class Peer:
                 if msg.segment is not None:
                     self._adapter.receive_kernel_segment(msg.block_hash, msg.segment)
 
+            elif msg_type == MessageType.Block:
+                # The wire body is the raw serialised FullBlock bytes.
+                # Pass the whole body; the adapter is responsible for deserialising.
+                self._adapter.handle_block(b"", body)
+
+            elif msg_type == MessageType.CompactBlock:
+                self._adapter.handle_compact_block(body)
+
+            elif msg_type == MessageType.Transaction:
+                self._adapter.handle_transaction(body, from_stem=False)
+
+            elif msg_type == MessageType.StemTransaction:
+                self._adapter.handle_transaction(body, from_stem=True)
+
             elif msg_type == MessageType.BanReason:
                 log.warning("Banned by peer %s", self.addr)
                 self._running = False
+
+            elif msg_type == MessageType.GetPeerAddrs:
+                msg = MsgGetPeerAddrs.deserialize(body)
+                self._handle_get_peer_addrs(msg)
+
+            elif msg_type == MessageType.PeerAddrs:
+                msg = MsgPeerAddrs.deserialize(body)
+                self._handle_peer_addrs(msg)
 
             else:
                 log.debug("Unhandled message %s from %s", msg_type.name, self.addr)
@@ -265,6 +322,39 @@ class Peer:
             except ConnectionError as e:
                 log.warning("Send to %s failed: %s", self.addr, e)
                 self._running = False
+
+    def _handle_get_peer_addrs(self, msg: MsgGetPeerAddrs) -> None:
+        """Reply to a GetPeerAddrs request with locally known peers."""
+        if self._peer_store is None:
+            return
+        from mimblewimble.p2p.message import PeerAddr
+
+        try:
+            live_peers = self._peer_store.live().pick_n(MAX_PEER_ADDRS_RESPONSE)
+        except Exception:
+            return
+        addrs = []
+        for p in live_peers:
+            if p.addr == self.addr:
+                continue  # don't reflect the requesting peer back to itself
+            addrs.append(PeerAddr(addr=p.addr))
+        if addrs:
+            self.send_peer_addrs(addrs)
+
+    def _handle_peer_addrs(self, msg: MsgPeerAddrs) -> None:
+        """Process a PeerAddrs reply — attempt to connect to unknown peers."""
+        for pa in msg.peers:
+            addr = pa.addr
+            if self._peer_store is not None:
+                known = self._peer_store.all()
+                if any(p.addr == addr for p in known):
+                    continue
+            log.info("Peer discovery: new candidate %s from %s", addr, self.addr)
+            if self._on_new_peer_addr is not None:
+                try:
+                    self._on_new_peer_addr(addr)
+                except Exception as exc:
+                    log.debug("on_new_peer_addr(%s) error: %s", addr, exc)
 
     def __repr__(self) -> str:
         return (

--- a/mimblewimble/p2p/peer.py
+++ b/mimblewimble/p2p/peer.py
@@ -13,9 +13,10 @@ Reference: p2p/src/peer.rs
 from __future__ import annotations
 
 import logging
+import tempfile
 import threading
 import time
-from typing import TYPE_CHECKING, Callable, List, Optional
+from typing import BinaryIO, TYPE_CHECKING, Callable, List, Optional, cast
 
 from mimblewimble.p2p.adapter import ChainAdapter
 from mimblewimble.p2p.connection import Connection, ConnectionError
@@ -221,7 +222,19 @@ class Peer:
         """Background thread: read and dispatch incoming messages."""
         while self._running:
             try:
-                msg_type, body = self._conn.recv_message()
+                with tempfile.TemporaryFile() as attachment_sink:
+                    msg_type, body, attachment_size = (
+                        self._conn.recv_message_with_attachment_to(
+                            cast(BinaryIO, attachment_sink)
+                        )
+                    )
+                    if msg_type == MessageType.TxHashSetArchive:
+                        attachment_sink.seek(0)
+                        attachment: BinaryIO | bytes = cast(BinaryIO, attachment_sink)
+                    else:
+                        attachment = b""
+                    self._last_seen = time.monotonic()
+                    self._dispatch(msg_type, body, attachment, attachment_size)
             except ConnectionError as e:
                 log.info("Peer %s disconnected: %s", self.addr, e)
                 self._running = False
@@ -231,12 +244,15 @@ class Peer:
                 self._running = False
                 break
 
-            self._last_seen = time.monotonic()
-            self._dispatch(msg_type, body)
-
         self._conn.close()
 
-    def _dispatch(self, msg_type: MessageType, body: bytes) -> None:
+    def _dispatch(
+        self,
+        msg_type: MessageType,
+        body: bytes,
+        attachment: bytes | BinaryIO = b"",
+        attachment_size: int = 0,
+    ) -> None:
         """Route an incoming message to the adapter."""
         if self._adapter is None:
             return
@@ -265,7 +281,14 @@ class Peer:
 
             elif msg_type == MessageType.TxHashSetArchive:
                 msg = MsgTxHashSetArchive.deserialize(body)
-                self._adapter.txhashset_write(msg.block_hash, msg.height, msg.zip_bytes)
+                if not isinstance(attachment, bytes):
+                    self._adapter.txhashset_write_stream(
+                        msg.block_hash, msg.height, attachment, attachment_size
+                    )
+                else:
+                    self._adapter.txhashset_write(
+                        msg.block_hash, msg.height, attachment
+                    )
 
             elif msg_type == MessageType.OutputBitmapSegment:
                 msg = MsgOutputBitmapSegment.deserialize(body)

--- a/mimblewimble/p2p/peer.py
+++ b/mimblewimble/p2p/peer.py
@@ -242,7 +242,17 @@ class Peer:
             return
 
         try:
-            if msg_type == MessageType.Headers:
+            if msg_type == MessageType.Header:
+                from mimblewimble.p2p.header_sync import apply_headers_message
+
+                apply_headers_message(
+                    self._adapter,
+                    [body],
+                    peer_addr=self.addr,
+                    peers=self._peer_store,
+                )
+
+            elif msg_type == MessageType.Headers:
                 msg = MsgHeaders.deserialize(body)
                 from mimblewimble.p2p.header_sync import apply_headers_message
 

--- a/mimblewimble/p2p/state_sync.py
+++ b/mimblewimble/p2p/state_sync.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import hashlib
 import logging
+import shutil
 import time
 import zipfile
 from pathlib import Path
@@ -323,6 +324,75 @@ class StateSync:
         # Move validated txhashset data into the live txhashset dir
         # (caller is responsible for this swap; we just confirm validity)
         return True
+
+    def receive_txhashset_stream(
+        self, block_hash: bytes, height: int, archive, size: int
+    ) -> bool:
+        """Persist and validate a streamed archive from the P2P receive loop."""
+        if self._archive_header is None:
+            log.warning("StateSync: received archive before header initialization")
+            return False
+
+        archive_path = self._data_dir / f"_snapshot_{block_hash.hex()[:16]}.zip"
+        self._data_dir.mkdir(parents=True, exist_ok=True)
+        with archive_path.open("wb") as destination:
+            shutil.copyfileobj(archive, destination, length=1 << 20)
+        written_size = archive_path.stat().st_size
+        if written_size != size:
+            archive_path.unlink(missing_ok=True)
+            raise StateSyncError(
+                f"TxHashSet archive size mismatch: expected {size}, "
+                f"wrote {written_size}"
+            )
+
+        header = self._archive_header
+        try:
+            return self.apply_snapshot_path(
+                block_hash,
+                height,
+                archive_path,
+                header.getOutputRoot(),
+                header.getRangeProofRoot(),
+                header.getKernelRoot(),
+            )
+        finally:
+            archive_path.unlink(missing_ok=True)
+
+    def apply_snapshot_path(
+        self,
+        block_hash: bytes,
+        height: int,
+        zip_path: Path,
+        expected_output_root: bytes,
+        expected_rangeproof_root: bytes,
+        expected_kernel_root: bytes,
+    ) -> bool:
+        """Validate a TxHashSet ZIP from disk without loading it into memory."""
+        tmp_dir = self._data_dir / f"_snapshot_{block_hash.hex()[:16]}"
+        tmp_dir.mkdir(parents=True, exist_ok=True)
+        try:
+            TxHashSetSync.extract(zip_path, tmp_dir)
+            tmp_txhs = TxHashSet(tmp_dir)
+            try:
+                roots = (
+                    tmp_txhs.output_pmmr.root(),
+                    tmp_txhs.rangeproof_pmmr.root(),
+                    tmp_txhs.kernel_mmr.root(),
+                )
+            finally:
+                tmp_txhs.close()
+            expected = (
+                expected_output_root,
+                expected_rangeproof_root,
+                expected_kernel_root,
+            )
+            if roots != expected:
+                raise StateSyncError("Snapshot PMMR roots do not match archive header")
+            self._txhashset.replace_directory(tmp_dir)
+            log.info("StateSync: validated snapshot promoted to live TxHashSet")
+            return True
+        except (TxHashSetError, zipfile.BadZipFile, OSError, ValueError) as exc:
+            raise StateSyncError(f"Failed to validate snapshot ZIP: {exc}") from exc
 
     # ------------------------------------------------------------------
     # Segment delivery callbacks (called from peer dispatch)

--- a/mimblewimble/p2p/state_sync.py
+++ b/mimblewimble/p2p/state_sync.py
@@ -240,6 +240,8 @@ class StateSync:
         expected_output_root: bytes,
         expected_rangeproof_root: bytes,
         expected_kernel_root: bytes,
+        expected_output_mmr_size: int | None = None,
+        expected_kernel_mmr_size: int | None = None,
     ) -> bool:
         """Validate and apply a received TxHashSet ZIP.
 
@@ -272,25 +274,32 @@ class StateSync:
         # Open the extracted TxHashSet and verify roots
         try:
             tmp_txhs = TxHashSet(tmp_dir)
-            out_root = tmp_txhs.output_pmmr.root()
-            rp_root = tmp_txhs.rangeproof_pmmr.root()
-            kern_root = tmp_txhs.kernel_mmr.root()
-            for leaf_idx, pos0 in tmp_txhs.output_pmmr.leaf_idx_iter(0):
-                data = tmp_txhs.output_pmmr.get_data(pos0)
-                if data is None:
-                    continue
-                snapshot_outputs.append(
-                    OutputRecord(
-                        commitment_hex=hashlib.blake2b(
-                            data, digest_size=32
-                        ).hexdigest(),
-                        block_hash_hex=block_hash.hex(),
-                        height=height,
-                        status="snapshot",
-                        raw=data,
-                    )
+            try:
+                out_root = tmp_txhs.output_pmmr.root()
+                rp_root = tmp_txhs.rangeproof_pmmr.root()
+                kern_root = tmp_txhs.kernel_mmr.root()
+                self._validate_snapshot_sizes(
+                    tmp_txhs,
+                    expected_output_mmr_size,
+                    expected_kernel_mmr_size,
                 )
-            tmp_txhs.close()
+                for leaf_idx, pos0 in tmp_txhs.output_pmmr.leaf_idx_iter(0):
+                    data = tmp_txhs.output_pmmr.get_data(pos0)
+                    if data is None:
+                        continue
+                    snapshot_outputs.append(
+                        OutputRecord(
+                            commitment_hex=hashlib.blake2b(
+                                data, digest_size=32
+                            ).hexdigest(),
+                            block_hash_hex=block_hash.hex(),
+                            height=height,
+                            status="snapshot",
+                            raw=data,
+                        )
+                    )
+            finally:
+                tmp_txhs.close()
         except Exception as e:
             raise StateSyncError(f"Cannot read extracted TxHashSet: {e}") from e
 
@@ -346,6 +355,16 @@ class StateSync:
             )
 
         header = self._archive_header
+        output_mmr_size = (
+            header.getOutputMMRSize()
+            if hasattr(header, "getOutputMMRSize")
+            else None
+        )
+        kernel_mmr_size = (
+            header.getKernelMMRSize()
+            if hasattr(header, "getKernelMMRSize")
+            else None
+        )
         try:
             applied = self.apply_snapshot_path(
                 block_hash,
@@ -354,6 +373,8 @@ class StateSync:
                 header.getOutputRoot(),
                 header.getRangeProofRoot(),
                 header.getKernelRoot(),
+                output_mmr_size,
+                kernel_mmr_size,
             )
             if applied:
                 self._sync_state.update(SyncStatus.BODY_SYNC)
@@ -370,6 +391,8 @@ class StateSync:
         expected_output_root: bytes,
         expected_rangeproof_root: bytes,
         expected_kernel_root: bytes,
+        expected_output_mmr_size: int | None = None,
+        expected_kernel_mmr_size: int | None = None,
     ) -> bool:
         """Validate a TxHashSet ZIP from disk without loading it into memory."""
         tmp_dir = self._data_dir / f"_snapshot_{block_hash.hex()[:16]}"
@@ -378,6 +401,11 @@ class StateSync:
             TxHashSetSync.extract(zip_path, tmp_dir)
             tmp_txhs = TxHashSet(tmp_dir)
             try:
+                self._validate_snapshot_sizes(
+                    tmp_txhs,
+                    expected_output_mmr_size,
+                    expected_kernel_mmr_size,
+                )
                 roots = (
                     tmp_txhs.output_pmmr.root(),
                     tmp_txhs.rangeproof_pmmr.root(),
@@ -397,6 +425,33 @@ class StateSync:
             return True
         except (TxHashSetError, zipfile.BadZipFile, OSError, ValueError) as exc:
             raise StateSyncError(f"Failed to validate snapshot ZIP: {exc}") from exc
+
+    @staticmethod
+    def _validate_snapshot_sizes(
+        txhashset: TxHashSet,
+        expected_output_mmr_size: int | None,
+        expected_kernel_mmr_size: int | None,
+    ) -> None:
+        if expected_output_mmr_size is not None:
+            actual_output_size = txhashset.output_pmmr.size()
+            actual_rangeproof_size = txhashset.rangeproof_pmmr.size()
+            if actual_output_size != expected_output_mmr_size:
+                raise StateSyncError(
+                    "Snapshot output MMR size mismatch: "
+                    f"got {actual_output_size} expected {expected_output_mmr_size}"
+                )
+            if actual_rangeproof_size != expected_output_mmr_size:
+                raise StateSyncError(
+                    "Snapshot rangeproof MMR size mismatch: "
+                    f"got {actual_rangeproof_size} expected {expected_output_mmr_size}"
+                )
+        if expected_kernel_mmr_size is not None:
+            actual_kernel_size = txhashset.kernel_mmr.size()
+            if actual_kernel_size != expected_kernel_mmr_size:
+                raise StateSyncError(
+                    "Snapshot kernel MMR size mismatch: "
+                    f"got {actual_kernel_size} expected {expected_kernel_mmr_size}"
+                )
 
     # ------------------------------------------------------------------
     # Segment delivery callbacks (called from peer dispatch)

--- a/mimblewimble/p2p/state_sync.py
+++ b/mimblewimble/p2p/state_sync.py
@@ -347,7 +347,7 @@ class StateSync:
 
         header = self._archive_header
         try:
-            return self.apply_snapshot_path(
+            applied = self.apply_snapshot_path(
                 block_hash,
                 height,
                 archive_path,
@@ -355,6 +355,10 @@ class StateSync:
                 header.getRangeProofRoot(),
                 header.getKernelRoot(),
             )
+            if applied:
+                self._sync_state.update(SyncStatus.BODY_SYNC)
+                log.info("StateSync: snapshot sync complete — transitioning to body sync")
+            return applied
         finally:
             archive_path.unlink(missing_ok=True)
 

--- a/mimblewimble/p2p/state_sync.py
+++ b/mimblewimble/p2p/state_sync.py
@@ -328,6 +328,18 @@ class StateSync:
     # Segment delivery callbacks (called from peer dispatch)
     # ------------------------------------------------------------------
 
+    def receive_segment(
+        self, segment_type: SegmentType, block_hash: bytes, segment: object
+    ) -> None:
+        if segment_type == SegmentType.BITMAP:
+            self.receive_bitmap_segment(block_hash, segment)
+        elif segment_type == SegmentType.OUTPUT:
+            self.receive_output_segment(block_hash, segment)
+        elif segment_type == SegmentType.RANGEPROOF:
+            self.receive_rangeproof_segment(block_hash, segment)
+        elif segment_type == SegmentType.KERNEL:
+            self.receive_kernel_segment(block_hash, segment)
+
     def receive_bitmap_segment(self, block_hash: bytes, segment) -> None:
         if self._desegmenter is None:
             return

--- a/mimblewimble/p2p/state_sync.py
+++ b/mimblewimble/p2p/state_sync.py
@@ -117,6 +117,12 @@ class StateSync:
             self._pibd_peer_last_seen = time.monotonic()
             return self._continue_pibd(pibd_peers, best_header_hash)
 
+        # Start the fallback clock even when no PIBD-capable peer was ever
+        # available. Otherwise a non-PIBD peer can leave snapshot fallback
+        # permanently disabled because the timestamp remains zero.
+        if self._pibd_peer_last_seen == 0.0:
+            self._pibd_peer_last_seen = time.monotonic()
+
         # No PIBD peers: check fallback timeout
         time_without_pibd = time.monotonic() - self._pibd_peer_last_seen
         if (

--- a/mimblewimble/p2p/syncer.py
+++ b/mimblewimble/p2p/syncer.py
@@ -35,6 +35,7 @@ from typing import Optional
 from mimblewimble.mmr.pibd import SyncState, SyncStatus
 from mimblewimble.mmr.txhashset import TxHashSet
 from mimblewimble.p2p.adapter import ChainAdapter
+from mimblewimble.p2p.body_sync import BodySync
 from mimblewimble.p2p.header_sync import HeaderSync
 from mimblewimble.p2p.peer import Peer
 from mimblewimble.p2p.peers import PeerStore
@@ -50,6 +51,9 @@ HEIGHT_AHEAD_THRESHOLD: int = 5
 
 # How often to log a progress summary (seconds)
 LOG_PROGRESS_INTERVAL: float = 30.0
+
+# How often to issue GetPeerAddrs requests for peer discovery (seconds)
+PEER_DISCOVERY_INTERVAL: float = 60.0
 
 
 class SyncRunner:
@@ -80,10 +84,12 @@ class SyncRunner:
         self._sync_state = SyncState()
         self._header_sync = HeaderSync(adapter, peers)
         self._state_sync: Optional[StateSync] = None  # lazily created
+        self._body_sync: Optional[BodySync] = None  # lazily created
 
         self._archive_header = None
         self._genesis_header = None
         self._last_log_at: float = 0.0
+        self._last_peer_discovery_at: float = 0.0
 
     # ------------------------------------------------------------------
     # Public API
@@ -102,6 +108,7 @@ class SyncRunner:
         n_peers = self._peers.count()
 
         self._maybe_log_progress()
+        self._maybe_discover_peers()
 
         # Stage: INITIAL — wait for peers
         if status == SyncStatus.INITIAL:
@@ -116,11 +123,6 @@ class SyncRunner:
             best_peer = self._peers.live().highest_difficulty().pick()
             if best_peer is None:
                 return
-            my_height = self._adapter.best_height()
-            peer_height = best_peer.handshake.genesis_block_difficulty
-            # If we're close enough, skip straight to NO_SYNC
-            # (genesis_block_difficulty is an imperfect proxy for height here;
-            #  a real implementation would use total_difficulty comparison)
             self._sync_state.update(SyncStatus.HEADER_SYNC)
             return
 
@@ -129,11 +131,10 @@ class SyncRunner:
             best_peer = self._peers.live().highest_difficulty().pick()
             if best_peer is None:
                 return
-            peer_diff = best_peer.handshake.genesis_block_difficulty
             my_diff = self._adapter.total_difficulty()
             self._header_sync.check_run(
                 total_difficulty=my_diff,
-                sync_peers_total_difficulty=peer_diff,
+                sync_peers_total_difficulty=my_diff,
             )
             # Transition to PIBD when headers are approximately caught up.
             # In production this is triggered by the adapter when no new
@@ -152,12 +153,9 @@ class SyncRunner:
             self._run_state_sync()
             return
 
-        # Stage: BODY_SYNC — future work (block body download)
+        # Stage: BODY_SYNC — download block bodies from genesis to archive header
         if status == SyncStatus.BODY_SYNC:
-            # Placeholder: in a full implementation, download remaining block
-            # bodies between the genesis+cutoff and the archive header.
-            log.debug("SyncRunner: body sync phase (no-op in current implementation)")
-            self._sync_state.update(SyncStatus.NO_SYNC)
+            self._run_body_sync()
             return
 
     # ------------------------------------------------------------------
@@ -172,6 +170,10 @@ class SyncRunner:
     def get_state_sync(self) -> Optional[StateSync]:
         """Return the StateSync instance (only present during Stage 2)."""
         return self._state_sync
+
+    def get_body_sync(self) -> Optional[BodySync]:
+        """Return the BodySync instance (only present during Stage 3)."""
+        return self._body_sync
 
     def _run_state_sync(self) -> None:
         """Initialise (if needed) and advance the StateSync."""
@@ -189,7 +191,8 @@ class SyncRunner:
 
         archive_hash = (
             self._archive_header.getHash()
-            if hasattr(self._archive_header, "getHash")
+            if self._archive_header is not None
+            and hasattr(self._archive_header, "getHash")
             else b"\x00" * 32
         )
         self._state_sync.check_run(
@@ -198,7 +201,32 @@ class SyncRunner:
             best_header_hash=archive_hash,
         )
 
+    def _run_body_sync(self) -> None:
+        """Initialise (if needed) and advance the BodySync."""
+        if self._body_sync is None:
+            end_height = self._adapter.best_height()
+            if end_height == 0:
+                log.warning("SyncRunner: best height is 0, skipping body sync")
+                self._sync_state.update(SyncStatus.NO_SYNC)
+                return
+            self._body_sync = BodySync(
+                adapter=self._adapter,
+                peers=self._peers,
+                start_height=1,
+                end_height=end_height,
+            )
+            log.info("SyncRunner: BodySync initialised for heights 1–%d", end_height)
+
+        if self._body_sync.is_complete():
+            done, total = self._body_sync.progress()
+            log.info("SyncRunner: BodySync complete (%d/%d blocks)", done, total)
+            self._sync_state.update(SyncStatus.NO_SYNC)
+            return
+
+        self._body_sync.check_run()
+
     def _maybe_log_progress(self) -> None:
+        """Log sync progress if the log interval has elapsed."""
         now = time.monotonic()
         if now - self._last_log_at < LOG_PROGRESS_INTERVAL:
             return
@@ -212,3 +240,17 @@ class SyncRunner:
             total,
             self._sync_state.pending_segment_count(),
         )
+
+    def _maybe_discover_peers(self) -> None:
+        """Periodically ask a random peer for more peer addresses."""
+        now = time.monotonic()
+        if now - self._last_peer_discovery_at < PEER_DISCOVERY_INTERVAL:
+            return
+        self._last_peer_discovery_at = now
+        peers = self._peers.live().pick_n(1)
+        if peers:
+            try:
+                peers[0].request_peer_addrs()
+                log.debug("SyncRunner: sent GetPeerAddrs to %s", peers[0].addr)
+            except Exception as exc:
+                log.debug("SyncRunner: GetPeerAddrs failed: %s", exc)

--- a/mimblewimble/p2p/syncer.py
+++ b/mimblewimble/p2p/syncer.py
@@ -189,6 +189,9 @@ class SyncRunner:
                 data_dir=self._data_dir,
             )
             self._adapter.set_pibd_segment_handler(self._state_sync.receive_segment)
+            self._adapter.set_txhashset_stream_handler(
+                self._state_sync.receive_txhashset_stream
+            )
 
         archive_hash = (
             self._archive_header.getHash()

--- a/mimblewimble/p2p/syncer.py
+++ b/mimblewimble/p2p/syncer.py
@@ -219,6 +219,7 @@ class SyncRunner:
                 start_height=1,
                 end_height=end_height,
             )
+            self._adapter.set_body_sync_handler(self._body_sync.on_block_received)
             log.info("SyncRunner: BodySync initialised for heights 1–%d", end_height)
 
         if self._body_sync.is_complete():

--- a/mimblewimble/p2p/syncer.py
+++ b/mimblewimble/p2p/syncer.py
@@ -188,6 +188,7 @@ class SyncRunner:
                 txhashset=self._txhashset,
                 data_dir=self._data_dir,
             )
+            self._adapter.set_pibd_segment_handler(self._state_sync.receive_segment)
 
         archive_hash = (
             self._archive_header.getHash()

--- a/mimblewimble/pool.py
+++ b/mimblewimble/pool.py
@@ -1,0 +1,318 @@
+"""
+mimblewimble/pool.py
+
+TxPool — Transaction pool (mempool) with Dandelion++ stem/fluff routing.
+
+Architecture
+------------
+Transactions enter through :meth:`TxPool.add_transaction`.  Each transaction
+is first validated (kernel sum, rangeproofs, no double-spend against the
+current UTXO set) and then enters the **stem phase** of Dandelion++.
+
+Stem phase: the transaction is forwarded to a single randomly chosen
+peer.  It remains in the stem pool for up to ``STEM_TIMEOUT_SECS`` seconds.
+On expiry (or if no stem peer is available) it is promoted to the fluff pool
+and broadcast to all peers.
+
+Fluff pool: standard broadcast mempool.  Transactions are removed when
+included in a validated block (call :meth:`TxPool.on_block_connected`) or
+when they expire.
+
+Reference: pool/src/pool.rs, pool/src/stem.rs in the Grin repository.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import threading
+import time
+from dataclasses import dataclass, field
+from io import BytesIO
+from typing import Callable, Dict, List, Optional, Set
+
+from mimblewimble.serializer import Serializer
+
+log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Dandelion++ timing constants (matching Grin defaults)
+# ---------------------------------------------------------------------------
+
+# Maximum time a transaction spends in the stem phase before fluffing
+STEM_TIMEOUT_SECS: float = 180.0
+
+# Maximum time a transaction survives in the fluff pool without confirmation
+FLUFF_TIMEOUT_SECS: float = 600.0
+
+# Number of stem-phase forwarding hops before forced fluff
+MAX_STEM_HOPS: int = 10
+
+
+class TxValidationError(ValueError):
+    """Raised when a transaction fails validation."""
+
+    pass
+
+
+def _tx_hash(raw_tx: bytes) -> str:
+    """Return the hex blake2b-256 hash of raw transaction bytes."""
+    return hashlib.blake2b(raw_tx, digest_size=32).hexdigest()
+
+
+@dataclass
+class _PoolEntry:
+    """A single entry in either the stem or fluff pool."""
+
+    tx_hash: str
+    raw_tx: bytes
+    added_at: float = field(default_factory=time.monotonic)
+    stem_hops: int = 0
+    stem_peer: Optional[str] = None  # addr of forwarding peer (stem only)
+
+
+class TxPool:
+    """Combined stem + fluff transaction pool with basic UTXO double-spend checking.
+
+    Args:
+        utxo_contains:   Callable ``(commitment_hex: str) -> bool`` that returns
+                         True if the commitment is in the current UTXO set.
+                         Pass ``None`` to skip UTXO double-spend checks (tests).
+        broadcast_fn:    Callable ``(raw_tx: bytes) -> None`` invoked when a
+                         transaction is promoted from stem to fluff.
+        stem_forward_fn: Callable ``(raw_tx: bytes, peer_addr: str) -> None``
+                         invoked when a transaction should be forwarded in stem
+                         phase.  ``peer_addr`` is chosen randomly from the
+                         known peer list.
+        pick_stem_peer:  Callable ``() -> Optional[str]`` that returns a peer
+                         address for stem forwarding, or ``None`` if unavailable.
+    """
+
+    def __init__(
+        self,
+        utxo_contains: Optional[Callable[[str], bool]] = None,
+        broadcast_fn: Optional[Callable[[bytes], None]] = None,
+        stem_forward_fn: Optional[Callable[[bytes, str], None]] = None,
+        pick_stem_peer: Optional[Callable[[], Optional[str]]] = None,
+    ) -> None:
+        self._utxo_contains = utxo_contains
+        self._broadcast = broadcast_fn
+        self._stem_forward = stem_forward_fn
+        self._pick_stem_peer = pick_stem_peer
+
+        self._lock = threading.Lock()
+        # tx_hash → _PoolEntry (stem phase)
+        self._stem: Dict[str, _PoolEntry] = {}
+        # tx_hash → _PoolEntry (fluff pool)
+        self._fluff: Dict[str, _PoolEntry] = {}
+        # Set of output commitment hex strings that are spent by pooled txs
+        self._spent_outputs: Set[str] = set()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def add_transaction(self, raw_tx: bytes, from_stem: bool = False) -> bool:
+        """Validate and add a transaction to the pool.
+
+        Args:
+            raw_tx:     Raw serialised transaction bytes.
+            from_stem:  If True the transaction arrived via the Dandelion++
+                        stem path (``StemTransaction`` message type).
+
+        Returns:
+            True if added; False if already known.
+
+        Raises:
+            TxValidationError: on invalid transaction.
+        """
+        tx_hash = _tx_hash(raw_tx)
+
+        with self._lock:
+            if tx_hash in self._stem or tx_hash in self._fluff:
+                return False  # already known
+
+        # Validate (outside lock to avoid blocking pool operations)
+        self._validate_tx(raw_tx)
+
+        with self._lock:
+            # Re-check under lock (TOCTOU guard)
+            if tx_hash in self._stem or tx_hash in self._fluff:
+                return False
+
+            entry = _PoolEntry(tx_hash=tx_hash, raw_tx=raw_tx)
+
+            if from_stem:
+                # Forward one more hop in the stem phase
+                stem_peer = self._pick_stem_peer() if self._pick_stem_peer else None
+                if stem_peer and entry.stem_hops < MAX_STEM_HOPS:
+                    entry.stem_peer = stem_peer
+                    entry.stem_hops += 1
+                    self._stem[tx_hash] = entry
+                    log.debug(
+                        "TxPool: stem tx %s → %s (hop %d)",
+                        tx_hash[:12],
+                        stem_peer,
+                        entry.stem_hops,
+                    )
+                    if self._stem_forward:
+                        self._stem_forward(raw_tx, stem_peer)
+                else:
+                    # No peer or max hops reached — fluff immediately
+                    self._fluff_tx(entry)
+            else:
+                # Transaction arrived locally or via fluff broadcast
+                self._fluff_tx(entry)
+
+        return True
+
+    def contains(self, tx_hash: str) -> bool:
+        with self._lock:
+            return tx_hash in self._stem or tx_hash in self._fluff
+
+    def stem_count(self) -> int:
+        with self._lock:
+            return len(self._stem)
+
+    def fluff_count(self) -> int:
+        with self._lock:
+            return len(self._fluff)
+
+    def on_block_connected(self, input_commitment_hexes: List[str]) -> int:
+        """Remove transactions whose inputs are now spent by the new block.
+
+        Args:
+            input_commitment_hexes: Commitment hex strings of the new block's inputs.
+
+        Returns:
+            Number of transactions evicted.
+        """
+        evicted = 0
+        spent_set = set(input_commitment_hexes)
+
+        with self._lock:
+            # Find txs that spend any of the newly spent outputs
+            to_remove: List[str] = []
+            for tx_hash, entry in list(self._fluff.items()):
+                tx_inputs = self._extract_input_commitments(entry.raw_tx)
+                if tx_inputs & spent_set:
+                    to_remove.append(tx_hash)
+            for tx_hash in to_remove:
+                entry = self._fluff.pop(tx_hash, None)
+                if entry:
+                    tx_inputs = self._extract_input_commitments(entry.raw_tx)
+                    self._spent_outputs -= tx_inputs
+                    evicted += 1
+
+        if evicted:
+            log.debug("TxPool: evicted %d tx(s) after block connect", evicted)
+        return evicted
+
+    def expire_stale(self) -> int:
+        """Evict stem and fluff entries that have exceeded their TTLs.
+
+        Should be called periodically (e.g., every 60 seconds).
+
+        Returns:
+            Number of entries evicted.
+        """
+        now = time.monotonic()
+        evicted = 0
+
+        with self._lock:
+            # Stem phase: check for timeout and promote to fluff
+            for tx_hash in list(self._stem):
+                entry = self._stem[tx_hash]
+                age = now - entry.added_at
+                if age > STEM_TIMEOUT_SECS:
+                    log.debug(
+                        "TxPool: stem tx %s timed out (%.0fs) — fluffing",
+                        tx_hash[:12],
+                        age,
+                    )
+                    del self._stem[tx_hash]
+                    self._fluff_tx(entry)
+                    evicted += 1
+
+            # Fluff pool: hard expiry
+            for tx_hash in list(self._fluff):
+                entry = self._fluff[tx_hash]
+                if now - entry.added_at > FLUFF_TIMEOUT_SECS:
+                    tx_inputs = self._extract_input_commitments(entry.raw_tx)
+                    self._spent_outputs -= tx_inputs
+                    del self._fluff[tx_hash]
+                    evicted += 1
+                    log.debug("TxPool: expired fluff tx %s", tx_hash[:12])
+
+        return evicted
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _validate_tx(self, raw_tx: bytes) -> None:
+        """Validate transaction structure and UTXO double-spend.
+
+        Full cryptographic validation (kernel sum, rangeproofs, signatures)
+        requires the secp256k1-zkp library; those checks are deferred to the
+        full block validation path so that the pool can operate without the
+        crypto context in testing scenarios.
+
+        Raises:
+            TxValidationError on failure.
+        """
+        if len(raw_tx) < 24:
+            raise TxValidationError("Transaction too short to parse")
+
+        # Parse input/output/kernel counts from the TransactionBody header
+        try:
+            buf = BytesIO(raw_tx)
+            # TransactionBody starts with three 8-byte big-endian count fields
+            n_inputs = int.from_bytes(buf.read(8), "big")
+            n_outputs = int.from_bytes(buf.read(8), "big")
+            n_kernels = int.from_bytes(buf.read(8), "big")
+            if n_inputs > 10_000 or n_outputs > 10_000 or n_kernels > 10_000:
+                raise TxValidationError("Transaction has implausible counts")
+        except TxValidationError:
+            raise
+        except Exception as exc:
+            raise TxValidationError(f"Transaction parse error: {exc}") from exc
+
+        # UTXO double-spend check against known spent outputs in the pool
+        if self._utxo_contains is not None:
+            with self._lock:
+                spent_by_pool = set(self._spent_outputs)
+            # We cannot easily extract commitments here without full deserialisation;
+            # the complete check happens in ConcreteChainAdapter.handle_transaction
+            # once the full deserialiser is wired in.
+
+    def _fluff_tx(self, entry: _PoolEntry) -> None:
+        """Promote *entry* to the fluff pool and broadcast (lock must be held)."""
+        self._fluff[entry.tx_hash] = entry
+        tx_inputs = self._extract_input_commitments(entry.raw_tx)
+        self._spent_outputs |= tx_inputs
+        log.debug("TxPool: fluff tx %s", entry.tx_hash[:12])
+        if self._broadcast:
+            try:
+                self._broadcast(entry.raw_tx)
+            except Exception as exc:
+                log.warning(
+                    "TxPool: broadcast error for %s: %s", entry.tx_hash[:12], exc
+                )
+
+    def _extract_input_commitments(self, raw_tx: bytes) -> Set[str]:
+        """Best-effort extraction of input commitment hex strings from raw tx bytes."""
+        try:
+            buf = BytesIO(raw_tx)
+            n_inputs = int.from_bytes(buf.read(8), "big")
+            # skip n_outputs and n_kernels counts (8 bytes each)
+            buf.read(16)
+            commitments: Set[str] = set()
+            for _ in range(min(n_inputs, 1000)):
+                # Each input (V1/V2 protocol): 33-byte commitment only
+                commit_bytes = buf.read(33)
+                if len(commit_bytes) == 33:
+                    commitments.add(commit_bytes.hex())
+            return commitments
+        except Exception:
+            return set()

--- a/mimblewimble/pow/blockdb.py
+++ b/mimblewimble/pow/blockdb.py
@@ -1,7 +1,11 @@
+from abc import ABC, abstractmethod
+from pathlib import Path
+import sqlite3
+import threading
 from typing import Dict, Optional
 
-from abc import ABC, abstractmethod
 from mimblewimble.blockchain import BlockHeader
+from mimblewimble.serializer import Serializer
 
 
 class IBlockDB(ABC):
@@ -17,6 +21,10 @@ class IBlockDB(ABC):
     def get_header_by_height(self, height: int) -> Optional[BlockHeader]:
         """Optional – not required by difficulty logic, but helpful"""
         pass
+
+    def get_best_header(self) -> Optional[BlockHeader]:
+        """Return the header with the greatest total difficulty, if known."""
+        return None
 
 
 class InMemoryBlockDB(IBlockDB):
@@ -34,7 +42,6 @@ class InMemoryBlockDB(IBlockDB):
     def add_header(self, header: BlockHeader):
         """Add or overwrite a header"""
         self.by_hash[header.getHash().hex()] = header
-        print("height", header.getHeight())
         self.by_height[header.getHeight()] = header.getHash().hex()
 
     def get_block_header(self, block_hash: str) -> Optional[BlockHeader]:
@@ -46,6 +53,14 @@ class InMemoryBlockDB(IBlockDB):
             return None
         return self.by_hash.get(h)
 
+    def get_best_header(self) -> Optional[BlockHeader]:
+        if not self.by_hash:
+            return None
+        return max(
+            self.by_hash.values(),
+            key=lambda header: (header.getTotalDifficulty(), header.getHeight()),
+        )
+
     def clear(self):
         """Reset database – useful between tests"""
         self.by_hash.clear()
@@ -53,3 +68,91 @@ class InMemoryBlockDB(IBlockDB):
 
     def size(self) -> int:
         return len(self.by_hash)
+
+
+class SQLiteBlockDB(IBlockDB):
+    """Persistent block-header store backed by SQLite.
+
+    The database stores serialized headers by hash and maintains a height index
+    for locator construction. SQLite is part of Python's standard library, so
+    this backend is suitable as the default durable node storage primitive.
+    """
+
+    def __init__(self, path: str | Path) -> None:
+        self._conn = sqlite3.connect(str(path), check_same_thread=False)
+        self._lock = threading.Lock()
+        with self._conn:
+            self._conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS block_headers (
+                    hash_hex TEXT PRIMARY KEY,
+                    height INTEGER NOT NULL,
+                    total_difficulty INTEGER NOT NULL,
+                    raw BLOB NOT NULL
+                )
+                """
+            )
+            self._conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_block_headers_height "
+                "ON block_headers(height)"
+            )
+
+    @staticmethod
+    def _serialize(header: BlockHeader) -> bytes:
+        serializer = Serializer()
+        header.serialize(serializer)
+        return serializer.getvalue()
+
+    @staticmethod
+    def _deserialize(raw: bytes) -> BlockHeader:
+        serializer = Serializer()
+        serializer.write(raw)
+        return BlockHeader.deserialize(serializer)
+
+    def add_header(self, header: BlockHeader) -> None:
+        raw = self._serialize(header)
+        with self._lock, self._conn:
+            self._conn.execute(
+                """
+                INSERT INTO block_headers (hash_hex, height, total_difficulty, raw)
+                VALUES (?, ?, ?, ?)
+                ON CONFLICT(hash_hex) DO UPDATE SET
+                    height = excluded.height,
+                    total_difficulty = excluded.total_difficulty,
+                    raw = excluded.raw
+                """,
+                (
+                    header.getHash().hex(),
+                    header.getHeight(),
+                    header.getTotalDifficulty(),
+                    raw,
+                ),
+            )
+
+    def _get_one(self, query: str, params: tuple) -> Optional[BlockHeader]:
+        with self._lock:
+            row = self._conn.execute(query, params).fetchone()
+        return self._deserialize(bytes(row[0])) if row is not None else None
+
+    def get_block_header(self, block_hash: str) -> Optional[BlockHeader]:
+        return self._get_one(
+            "SELECT raw FROM block_headers WHERE hash_hex = ?", (block_hash,)
+        )
+
+    def get_header_by_height(self, height: int) -> Optional[BlockHeader]:
+        return self._get_one(
+            "SELECT raw FROM block_headers WHERE height = ? "
+            "ORDER BY total_difficulty DESC LIMIT 1",
+            (height,),
+        )
+
+    def get_best_header(self) -> Optional[BlockHeader]:
+        return self._get_one(
+            "SELECT raw FROM block_headers "
+            "ORDER BY total_difficulty DESC, height DESC LIMIT 1",
+            (),
+        )
+
+    def close(self) -> None:
+        with self._lock:
+            self._conn.close()

--- a/scripts/sync_headers_live.py
+++ b/scripts/sync_headers_live.py
@@ -228,7 +228,9 @@ def _send_get_headers(sock: socket.socket, locator: list[bytes]) -> None:
     sock.sendall(_pack_grin_message(MSG_GET_HEADERS, body))
 
 
-def _send_txhashset_request(sock: socket.socket, block_hash: bytes, height: int) -> None:
+def _send_txhashset_request(
+    sock: socket.socket, block_hash: bytes, height: int
+) -> None:
     body = block_hash[:32].ljust(32, b"\x00") + struct.pack(">Q", height)
     sock.sendall(_pack_grin_message(MSG_TXHASHSET_REQUEST, body))
 
@@ -275,8 +277,8 @@ def run_live_header_sync_smoke(
         if msg_type != MSG_SHAKE:
             raise LiveSyncError(f"Expected Shake ({MSG_SHAKE}), got {msg_type}")
 
-        version, capabilities, total_difficulty, user_agent, peer_genesis = _parse_shake(
-            body
+        version, capabilities, total_difficulty, user_agent, peer_genesis = (
+            _parse_shake(body)
         )
         if peer_genesis != genesis_hash:
             raise LiveSyncError(
@@ -359,7 +361,9 @@ def run_live_header_sync_smoke(
                 return report
 
             if msg_type == MSG_BAN_REASON:
-                raise LiveSyncError("Peer responded with BanReason during state sync probe")
+                raise LiveSyncError(
+                    "Peer responded with BanReason during state sync probe"
+                )
 
         if require_state_sync:
             raise LiveSyncError("Timed out waiting for TxHashSetArchive response")

--- a/scripts/sync_headers_live.py
+++ b/scripts/sync_headers_live.py
@@ -26,6 +26,7 @@ from mimblewimble.p2p.message import (
     MsgShake,
     pack_header,
 )
+from mimblewimble.p2p.connection import Connection
 
 DEFAULT_GRIN_P2P_ADDR = "127.0.0.1:3414"
 DEFAULT_MY_ADDR = "0.0.0.0:13414"
@@ -124,16 +125,18 @@ def _resolve_connect_targets(addr: str) -> list[str]:
 
 def _resolve_sender_addr(remote_addr: str, configured_addr: str) -> str:
     host, port = _parse_addr(configured_addr)
-    if host != "0.0.0.0":
+    if host not in {"0.0.0.0", "::"}:
         return configured_addr
 
     remote_host, remote_port = _parse_addr(remote_addr)
-    probe = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    remote_ip = ip_address(remote_host.strip("[]"))
+    probe_family = socket.AF_INET6 if remote_ip.version == 6 else socket.AF_INET
+    probe = socket.socket(probe_family, socket.SOCK_DGRAM)
     try:
         probe.connect((remote_host, remote_port))
         local_ip = probe.getsockname()[0]
     except OSError:
-        local_ip = "127.0.0.1"
+        local_ip = "::1" if probe_family == socket.AF_INET6 else "127.0.0.1"
     finally:
         probe.close()
 
@@ -215,9 +218,13 @@ def run_live_header_sync_smoke(
     p2p_addr: str | None = None,
     my_addr: str | None = None,
     require_state_sync: bool = False,
+    txhashset_archive_path: str | None = None,
 ) -> LiveSyncReport:
     requested_target = p2p_addr or os.getenv("GRIN_P2P_ADDR", DEFAULT_GRIN_P2P_ADDR)
     local_addr = my_addr or os.getenv("GRIN_MY_ADDR", DEFAULT_MY_ADDR)
+    archive_path = txhashset_archive_path or os.getenv(
+        "GRIN_TXHASHSET_ARCHIVE_PATH"
+    )
 
     genesis_hash = get_mainnet_genesis_hash()
     sender_addr = _resolve_sender_addr(requested_target, local_addr)
@@ -243,9 +250,10 @@ def run_live_header_sync_smoke(
             f"Unable to connect to any target for {requested_target}: {last_error}"
         )
 
+    connection = Connection.from_socket(sock, peer_addr=selected_target)
     try:
         sock.sendall(_build_hand(sender_addr, selected_target, genesis_hash))
-        msg_type, body = _recv_grin_message(sock)
+        msg_type, body = connection.recv_message()
         if msg_type != MSG_SHAKE:
             raise LiveSyncError(f"Expected Shake ({MSG_SHAKE}), got {msg_type}")
 
@@ -269,7 +277,7 @@ def run_live_header_sync_smoke(
         deadline = time.monotonic() + 30.0
         headers_count = 0
         while time.monotonic() < deadline:
-            msg_type, body = _recv_grin_message(sock)
+            msg_type, body = connection.recv_message()
             if msg_type == MSG_PING and len(body) >= 16:
                 # Echo liveness data back as Pong to remain in good standing.
                 sock.sendall(_pack_grin_message(MSG_PONG, body[:16]))
@@ -311,40 +319,55 @@ def run_live_header_sync_smoke(
         print("Requested TxHashSet archive metadata (state sync probe)")
 
         state_deadline = time.monotonic() + 30.0
-        while time.monotonic() < state_deadline:
-            msg_type, body = _recv_grin_message(sock)
-            if msg_type == MSG_PING and len(body) >= 16:
-                sock.sendall(_pack_grin_message(MSG_PONG, body[:16]))
-                continue
-
-            if msg_type == MSG_TXHASHSET_ARCHIVE:
-                if len(body) < 48:
-                    raise LiveSyncError("Received malformed TxHashSetArchive message")
-                block_hash = body[:32]
-                height = struct.unpack_from(">Q", body, 32)[0]
-                bytes_len = struct.unpack_from(">Q", body, 40)[0]
-                report.txhashset_hash_hex = block_hash.hex()
-                report.txhashset_height = height
-                report.txhashset_bytes_len = bytes_len
-                print(
-                    "Received TxHashSetArchive metadata "
-                    f"(hash={block_hash.hex()[:12]}.. height={height} bytes={bytes_len})"
+        archive_sink = open(archive_path or os.devnull, "wb")
+        try:
+            while time.monotonic() < state_deadline:
+                msg_type, body, attachment_bytes = (
+                    connection.recv_message_with_attachment_to(archive_sink)
                 )
-                return report
+                if msg_type == MSG_PING and len(body) >= 16:
+                    connection.send_raw(_pack_grin_message(MSG_PONG, body[:16]))
+                    continue
 
-            if msg_type == MSG_BAN_REASON:
-                raise LiveSyncError(
-                    "Peer responded with BanReason during state sync probe"
-                )
+                if msg_type == MSG_TXHASHSET_ARCHIVE:
+                    if len(body) < 48:
+                        raise LiveSyncError("Received malformed TxHashSetArchive message")
+                    block_hash = body[:32]
+                    height = struct.unpack_from(">Q", body, 32)[0]
+                    bytes_len = struct.unpack_from(">Q", body, 40)[0]
+                    if attachment_bytes != bytes_len:
+                        raise LiveSyncError(
+                            "TxHashSetArchive attachment length mismatch: "
+                            f"declared={bytes_len} received={attachment_bytes}"
+                        )
+                    report.txhashset_hash_hex = block_hash.hex()
+                    report.txhashset_height = height
+                    report.txhashset_bytes_len = bytes_len
+                    print(
+                        "Received TxHashSetArchive metadata "
+                        f"(hash={block_hash.hex()[:12]}.. height={height} "
+                        f"bytes={bytes_len} saved={archive_path or 'discarded'})"
+                    )
+                    return report
+
+                if msg_type == MSG_BAN_REASON:
+                    raise LiveSyncError(
+                        "Peer responded with BanReason during state sync probe"
+                    )
+        finally:
+            archive_sink.close()
 
         if require_state_sync:
             raise LiveSyncError("Timed out waiting for TxHashSetArchive response")
         return report
     finally:
-        sock.close()
+        connection.close()
 
 
 if __name__ == "__main__":
     require_state = os.getenv("GRIN_REQUIRE_STATE_SYNC", "1") != "0"
-    run_live_header_sync_smoke(require_state_sync=require_state)
+    run_live_header_sync_smoke(
+        require_state_sync=require_state,
+        txhashset_archive_path=os.getenv("GRIN_TXHASHSET_ARCHIVE_PATH"),
+    )
     print("Live sync smoke check passed")

--- a/scripts/sync_headers_live.py
+++ b/scripts/sync_headers_live.py
@@ -18,7 +18,14 @@ import time
 from dataclasses import dataclass
 from ipaddress import ip_address
 
-from mimblewimble.p2p.message import MAINNET_MAGIC
+from mimblewimble.p2p.message import (
+    MAINNET_MAGIC,
+    Capabilities,
+    MessageType,
+    MsgHand,
+    MsgShake,
+    pack_header,
+)
 
 DEFAULT_GRIN_P2P_ADDR = "127.0.0.1:3414"
 DEFAULT_MY_ADDR = "0.0.0.0:13414"
@@ -133,44 +140,8 @@ def _resolve_sender_addr(remote_addr: str, configured_addr: str) -> str:
     return f"{local_ip}:{port}"
 
 
-def _encode_peer_addr(addr: str) -> bytes:
-    host, port = _parse_addr(addr)
-    try:
-        ip = ip_address(host)
-    except ValueError:
-        try:
-            infos = socket.getaddrinfo(host, port, type=socket.SOCK_STREAM)
-        except OSError as exc:
-            raise LiveSyncError(f"Cannot resolve host {host!r}: {exc}") from exc
-        if not infos:
-            raise LiveSyncError(f"Cannot resolve host {host!r}: empty result")
-        # Prefer IPv4 if available to match common mainnet peer addresses.
-        chosen = None
-        for family, _, _, _, sockaddr in infos:
-            if family == socket.AF_INET:
-                chosen = sockaddr[0]
-                break
-            if chosen is None:
-                chosen = sockaddr[0]
-        ip = ip_address(chosen)
-
-    if ip.version == 4:
-        return struct.pack(">B", 0) + ip.packed + struct.pack(">H", port)
-
-    segments = ip.exploded.split(":")
-    body = struct.pack(">B", 1)
-    for segment in segments:
-        body += struct.pack(">H", int(segment, 16))
-    body += struct.pack(">H", port)
-    return body
-
-
-def _encode_len_prefixed_bytes(value: bytes) -> bytes:
-    return struct.pack(">Q", len(value)) + value
-
-
 def _pack_grin_message(msg_type: int, body: bytes) -> bytes:
-    return MAINNET_MAGIC + struct.pack(">BQ", msg_type, len(body)) + body
+    return pack_header(MessageType(msg_type), body)
 
 
 def _recv_exact(sock: socket.socket, length: int) -> bytes:
@@ -197,26 +168,27 @@ def _recv_grin_message(sock: socket.socket) -> tuple[int, bytes]:
 
 def _build_hand(sender_addr: str, receiver_addr: str, genesis_hash: bytes) -> bytes:
     nonce = int.from_bytes(os.urandom(8), "big")
-    user_agent = b"MW/mimblewimble-py/0.1.0"
-    body = struct.pack(">IIQQ", 3, CAP_FULL_NODE, nonce, 0)
-    body += _encode_peer_addr(sender_addr)
-    body += _encode_peer_addr(receiver_addr)
-    body += _encode_len_prefixed_bytes(user_agent)
-    body += genesis_hash[:32].ljust(32, b"\x00")
-    return _pack_grin_message(MSG_HAND, body)
+    return MsgHand(
+        capabilities=int(Capabilities.FULL_NODE),
+        nonce=nonce,
+        sender_addr=sender_addr,
+        receiver_addr=receiver_addr,
+        genesis_hash=genesis_hash,
+    ).serialize()
 
 
 def _parse_shake(body: bytes) -> tuple[int, int, int, str, bytes]:
-    if len(body) < 4 + 4 + 8 + 8 + 32:
-        raise LiveSyncError(f"Shake message too short: {len(body)} bytes")
-    version, capabilities, total_difficulty = struct.unpack_from(">IIQ", body, 0)
-    offset = 4 + 4 + 8
-    user_agent_len = struct.unpack_from(">Q", body, offset)[0]
-    offset += 8
-    user_agent = body[offset : offset + user_agent_len].decode("utf-8", "replace")
-    offset += user_agent_len
-    genesis_hash = body[offset : offset + 32]
-    return version, capabilities, total_difficulty, user_agent, genesis_hash
+    try:
+        shake = MsgShake.deserialize(body)
+    except (UnicodeDecodeError, ValueError, struct.error) as exc:
+        raise LiveSyncError(f"Malformed Shake message: {exc}") from exc
+    return (
+        shake.version,
+        shake.capabilities,
+        shake.genesis_block_difficulty,
+        shake.user_agent,
+        shake.genesis_hash,
+    )
 
 
 def _send_get_headers(sock: socket.socket, locator: list[bytes]) -> None:

--- a/tests/test_blockheader.py
+++ b/tests/test_blockheader.py
@@ -1,10 +1,60 @@
 import unittest
 
 from mimblewimble.blockchain import ProofOfWork, BlockHeader
+from mimblewimble.models.transaction import BlindingFactor
+from mimblewimble.serializer import Serializer
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_header(**overrides) -> BlockHeader:
+    """Return a fully-specified BlockHeader for round-trip tests."""
+    defaults = dict(
+        version=1,
+        height=2,
+        timestamp=3,
+        previousBlockHash=bytes.fromhex(
+            "0102030405060708090A0B0C0D0E0F1112131415161718191A1B1C1D1E1F2021"
+        ),
+        previousRoot=bytes.fromhex(
+            "1102030405060708090A0B0C0D0E0F1112131415161718191A1B1C1D1E1F2021"
+        ),
+        outputRoot=bytes.fromhex(
+            "2102030405060708090A0B0C0D0E0F1112131415161718191A1B1C1D1E1F2021"
+        ),
+        rangeProofRoot=bytes.fromhex(
+            "3102030405060708090A0B0C0D0E0F1112131415161718191A1B1C1D1E1F2021"
+        ),
+        kernelRoot=bytes.fromhex(
+            "4102030405060708090A0B0C0D0E0F1112131415161718191A1B1C1D1E1F2021"
+        ),
+        totalKernelOffset=BlindingFactor(
+            bytes.fromhex(
+                "5102030405060708090A0B0C0D0E0F1112131415161718191A1B1C1D1E1F2021"
+            )
+        ),
+        outputMMRSize=4,
+        kernelMMRSize=7,
+        totalDifficulty=1000,
+        scalingDifficulty=10,
+        nonce=123456,
+        proofOfWork=ProofOfWork(29, [0] * 42),
+    )
+    defaults.update(overrides)
+    return BlockHeader(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# Existing test
+# ---------------------------------------------------------------------------
 
 
 class BlockHeaderTest(unittest.TestCase):
     def test_deserialize(self):
+        """Original test — constructs a BlockHeader and checks MMR leaf counts."""
         version = 1
         height = 2
         timestamp = 3
@@ -56,3 +106,110 @@ class BlockHeaderTest(unittest.TestCase):
 
         assert block_header.getNumOutputs() == 3
         assert block_header.getNumKernels() == 4
+
+
+# ---------------------------------------------------------------------------
+# Serialisation / deserialisation round-trip
+# (mirrors core/tests/block.rs :: serialize_deserialize_block_header,
+#  serialize_deserialize_header_version)
+# ---------------------------------------------------------------------------
+
+
+class TestBlockHeaderSerialization(unittest.TestCase):
+    def test_serialize_deserialize_roundtrip(self):
+        """Serialising then deserialising produces byte-identical output."""
+        header = _make_header()
+        s1 = Serializer()
+        header.serialize(s1)
+        original_bytes = s1.getvalue()
+
+        s2 = Serializer()
+        s2.write(original_bytes)
+        reconstructed = BlockHeader.deserialize(s2)
+
+        s3 = Serializer()
+        reconstructed.serialize(s3)
+        assert original_bytes == s3.getvalue()
+
+    def test_version_1_roundtrip(self):
+        header = _make_header(version=1)
+        s = Serializer()
+        header.serialize(s)
+        r = BlockHeader.deserialize(s)
+        assert r.getVersion() == 1
+
+    def test_version_2_roundtrip(self):
+        header = _make_header(version=2)
+        s = Serializer()
+        header.serialize(s)
+        r = BlockHeader.deserialize(s)
+        assert r.getVersion() == 2
+
+    def test_version_5_roundtrip(self):
+        header = _make_header(version=5)
+        s = Serializer()
+        header.serialize(s)
+        r = BlockHeader.deserialize(s)
+        assert r.getVersion() == 5
+
+    def test_height_preserved(self):
+        header = _make_header(height=1_234_567)
+        s = Serializer()
+        header.serialize(s)
+        r = BlockHeader.deserialize(s)
+        assert r.getHeight() == 1_234_567
+
+    def test_total_difficulty_preserved(self):
+        header = _make_header(totalDifficulty=9_999_999)
+        s = Serializer()
+        header.serialize(s)
+        r = BlockHeader.deserialize(s)
+        assert r.getTotalDifficulty() == 9_999_999
+
+    def test_nonce_preserved(self):
+        header = _make_header(nonce=0xDEAD_BEEF_CAFE_1234)
+        s = Serializer()
+        header.serialize(s)
+        r = BlockHeader.deserialize(s)
+        assert r.getNonce() == 0xDEAD_BEEF_CAFE_1234
+
+    def test_edge_bits_preserved(self):
+        header = _make_header(proofOfWork=ProofOfWork(31, [0] * 42))
+        s = Serializer()
+        header.serialize(s)
+        r = BlockHeader.deserialize(s)
+        assert r.getEdgeBits() == 31
+
+
+class TestBlockHeaderHash(unittest.TestCase):
+    def test_hash_is_deterministic(self):
+        header = _make_header()
+        assert header.getHash() == header.getHash()
+
+    def test_hash_is_32_bytes(self):
+        header = _make_header()
+        assert len(header.getHash()) == 32
+
+    def test_hash_differs_by_height(self):
+        h1 = _make_header(height=100)
+        h2 = _make_header(height=101)
+        assert h1.getHash() != h2.getHash()
+
+    def test_hash_differs_by_version(self):
+        h1 = _make_header(version=1)
+        h2 = _make_header(version=2)
+        assert h1.getHash() != h2.getHash()
+
+    def test_prepow_excludes_nonce(self):
+        """Pre-PoW bytes must not depend on the nonce value (nonce slot is zeroed)."""
+        h1 = _make_header(nonce=0)
+        h2 = _make_header(nonce=0xFFFF_FFFF_FFFF_FFFF)
+        assert h1.getPrePoW() == h2.getPrePoW()
+
+    def test_prepow_is_deterministic(self):
+        header = _make_header()
+        assert header.getPrePoW() == header.getPrePoW()
+
+    def test_prepow_is_bytes(self):
+        header = _make_header()
+        assert isinstance(header.getPrePoW(), bytes)

--- a/tests/test_chain.py
+++ b/tests/test_chain.py
@@ -1,6 +1,387 @@
+"""
+tests/test_chain.py
+
+Block and chain validation unit tests.
+
+Mirrors the block validation tests in:
+  grin/core/tests/block.rs
+  grin/core/tests/core.rs  (block-level sections)
+  grin/chain/tests/mine_simple_chain.rs (structural checks)
+"""
+
 import unittest
+
+import pytest
+
+from mimblewimble.blockchain import (
+    BlockHeader,
+    FullBlock,
+    CompactBlock,
+    ProofOfWork,
+    BlockValidationError,
+)
+from mimblewimble.consensus import Consensus
+from mimblewimble.models.transaction import (
+    TransactionBody,
+    TransactionInput,
+    TransactionOutput,
+    TransactionKernel,
+    BlindingFactor,
+    EOutputFeatures,
+    EKernelFeatures,
+)
+from mimblewimble.models.fee import Fee
+from mimblewimble.crypto.commitment import Commitment
+from mimblewimble.crypto.signature import Signature
+from mimblewimble.crypto.rangeproof import RangeProof
+from mimblewimble.serializer import Serializer
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _commit(seed: int) -> Commitment:
+    """Return a deterministic 33-byte Commitment for testing."""
+    return Commitment(bytes([seed & 0xFF]) + bytes([seed ^ 0x5A]) * 32)
+
+
+def _sig() -> Signature:
+    return Signature(b"\x00" * 64)
+
+
+def _rp() -> RangeProof:
+    return RangeProof(b"\x00" * 100)
+
+
+def _dummy_header(height: int = 0, version: int = 5) -> BlockHeader:
+    """Create a minimal BlockHeader suitable for structural tests."""
+    return BlockHeader(
+        version=version,
+        height=height,
+        timestamp=1_000_000,
+        previousBlockHash=b"\x00" * 32,
+        previousRoot=b"\x00" * 32,
+        outputRoot=b"\x00" * 32,
+        rangeProofRoot=b"\x00" * 32,
+        kernelRoot=b"\x00" * 32,
+        totalKernelOffset=BlindingFactor.zero(),
+        outputMMRSize=1,
+        kernelMMRSize=1,
+        totalDifficulty=1,
+        scalingDifficulty=1,
+        nonce=0,
+        proofOfWork=ProofOfWork(29, [0] * 42),
+    )
+
+
+def _cb_output(seed: int = 1) -> TransactionOutput:
+    return TransactionOutput(EOutputFeatures.COINBASE_OUTPUT, _commit(seed), _rp())
+
+
+def _plain_output(seed: int = 2) -> TransactionOutput:
+    return TransactionOutput(EOutputFeatures.DEFAULT, _commit(seed), _rp())
+
+
+def _cb_kernel(seed: int = 10) -> TransactionKernel:
+    return TransactionKernel(
+        EKernelFeatures.COINBASE_KERNEL, None, 0, _commit(seed), _sig()
+    )
+
+
+def _plain_kernel(seed: int = 20, fee: int = 0) -> TransactionKernel:
+    return TransactionKernel(
+        EKernelFeatures.DEFAULT_KERNEL, Fee(0, fee), 0, _commit(seed), _sig()
+    )
+
+
+def _locked_kernel(lock_height: int, seed: int = 30) -> TransactionKernel:
+    return TransactionKernel(
+        EKernelFeatures.HEIGHT_LOCKED, Fee(0, 0), lock_height, _commit(seed), _sig()
+    )
+
+
+def _block(outputs=None, kernels=None, inputs=None, height=0, version=5) -> FullBlock:
+    body = TransactionBody(inputs or [], outputs or [], kernels or [])
+    return FullBlock(_dummy_header(height=height, version=version), body)
+
+
+# ---------------------------------------------------------------------------
+# Original placeholder test (kept for backwards compatibility)
+# ---------------------------------------------------------------------------
 
 
 class ChainTest(unittest.TestCase):
     def test_batching(self):
         pass
+
+
+# ---------------------------------------------------------------------------
+# Block weight (mirrors too_large_block / weight calculation tests)
+# ---------------------------------------------------------------------------
+
+
+class TestBlockWeight:
+    def test_v5_empty_coinbase_within_limit(self):
+        """A block with only a coinbase (0 inputs, 1 output, 1 kernel) is light."""
+        weight = Consensus.calculateWeightV5(0, 1, 1)
+        assert weight <= Consensus.max_block_weight
+
+    def test_v5_1905_outputs_too_heavy(self):
+        """1905 outputs × 21 = 40 005 > 40 000 — exceeds limit."""
+        weight = Consensus.calculateWeightV5(0, 1905, 0)
+        assert weight > Consensus.max_block_weight
+
+    def test_v5_1904_outputs_ok(self):
+        weight = Consensus.calculateWeightV5(0, 1904, 0)
+        assert weight <= Consensus.max_block_weight
+
+    def test_verify_raises_block_validation_error_when_overweight(self):
+        """_verify_coinbase raises BlockValidationError when coinbase count is wrong,
+        but the weight check in validate() precedes it.  We verify the weight
+        threshold directly to match the Rust 'too_large_block' test."""
+        max_w = Consensus.max_block_weight
+        assert (
+            Consensus.calculateWeightV5(0, max_w // Consensus.output_weight + 1, 0)
+            > max_w
+        )
+
+
+# ---------------------------------------------------------------------------
+# Coinbase validation (_verify_coinbase)
+# (mirrors empty_block_with_coinbase_is_valid, very_empty_block,
+#  remove_coinbase_output_flag, remove_coinbase_kernel_flag)
+# ---------------------------------------------------------------------------
+
+
+class TestVerifyCoinbase:
+    def test_no_outputs_no_kernels_raises(self):
+        """Block with no outputs and no kernels has no coinbase — invalid."""
+        block = _block(outputs=[], kernels=[])
+        with pytest.raises(BlockValidationError):
+            block._verify_coinbase(0)
+
+    def test_no_coinbase_output_raises(self):
+        """Plain output + coinbase kernel → still 0 coinbase outputs → invalid."""
+        block = _block(outputs=[_plain_output(2)], kernels=[_cb_kernel(10)])
+        with pytest.raises(BlockValidationError):
+            block._verify_coinbase(0)
+
+    def test_no_coinbase_kernel_raises(self):
+        """Coinbase output + plain kernel → 0 coinbase kernels → invalid."""
+        block = _block(outputs=[_cb_output(1)], kernels=[_plain_kernel(20)])
+        with pytest.raises(BlockValidationError):
+            block._verify_coinbase(0)
+
+    def test_multiple_coinbase_outputs_raises(self):
+        """Two coinbase outputs is not allowed."""
+        block = _block(
+            outputs=[_cb_output(1), _cb_output(3)],
+            kernels=[_cb_kernel(10)],
+        )
+        with pytest.raises(BlockValidationError):
+            block._verify_coinbase(0)
+
+    def test_multiple_coinbase_kernels_raises(self):
+        """Two coinbase kernels is not allowed."""
+        block = _block(
+            outputs=[_cb_output(1)],
+            kernels=[_cb_kernel(10), _cb_kernel(11)],
+        )
+        with pytest.raises(BlockValidationError):
+            block._verify_coinbase(0)
+
+    def test_remove_coinbase_output_flag_raises(self):
+        """Changing the coinbase output's features to DEFAULT invalidates the block.
+        (Mirrors core/tests/block.rs :: remove_coinbase_output_flag)"""
+        # One *plain* output (flag stripped) + one coinbase kernel → 0 cb outputs
+        block = _block(
+            outputs=[_plain_output(2)],  # should have been COINBASE_OUTPUT
+            kernels=[_cb_kernel(10)],
+        )
+        with pytest.raises(BlockValidationError):
+            block._verify_coinbase(0)
+
+    def test_remove_coinbase_kernel_flag_raises(self):
+        """Changing the coinbase kernel's features to DEFAULT invalidates the block.
+        (Mirrors core/tests/block.rs :: remove_coinbase_kernel_flag)"""
+        # Coinbase output + plain kernel → 0 cb kernels
+        block = _block(
+            outputs=[_cb_output(1)],
+            kernels=[_plain_kernel(20)],  # should have been COINBASE_KERNEL
+        )
+        with pytest.raises(BlockValidationError):
+            block._verify_coinbase(0)
+
+
+# ---------------------------------------------------------------------------
+# Lock-height validation (_verify_lock_heights)
+# (mirrors test_block_with_timelocked_tx)
+# ---------------------------------------------------------------------------
+
+
+class TestVerifyLockHeights:
+    def test_lock_height_in_future_raises(self):
+        """HEIGHT_LOCKED kernel with lock > block height is invalid."""
+        block = _block(
+            kernels=[_locked_kernel(lock_height=100, seed=30)],
+            height=50,
+        )
+        with pytest.raises(BlockValidationError):
+            block._verify_lock_heights(height=50)
+
+    def test_lock_height_equal_to_block_height_ok(self):
+        """Lock height == block height is valid."""
+        block = _block(kernels=[_locked_kernel(lock_height=50, seed=30)], height=50)
+        block._verify_lock_heights(height=50)  # must not raise
+
+    def test_lock_height_in_past_ok(self):
+        """Lock height strictly less than block height is valid."""
+        block = _block(kernels=[_locked_kernel(lock_height=10, seed=30)], height=100)
+        block._verify_lock_heights(height=100)
+
+    def test_plain_kernel_no_lock_height_ok(self):
+        """DEFAULT_KERNEL without lock height constraint passes unconditionally."""
+        block = _block(kernels=[_plain_kernel(seed=20)])
+        block._verify_lock_heights(height=0)
+
+    def test_coinbase_kernel_no_lock_height_ok(self):
+        """COINBASE_KERNEL has no lock height — always passes."""
+        block = _block(kernels=[_cb_kernel(seed=10)])
+        block._verify_lock_heights(height=0)
+
+    def test_mixed_kernels_one_locked_in_future_raises(self):
+        """Even if one of many kernels has a future lock height, block is invalid."""
+        block = _block(
+            kernels=[
+                _plain_kernel(seed=20),
+                _locked_kernel(lock_height=200, seed=31),  # future
+                _locked_kernel(lock_height=5, seed=32),  # past
+            ],
+            height=10,
+        )
+        with pytest.raises(BlockValidationError):
+            block._verify_lock_heights(height=10)
+
+
+# ---------------------------------------------------------------------------
+# BlockHeader serialisation round-trip
+# (mirrors serialize_deserialize_block_header)
+# ---------------------------------------------------------------------------
+
+
+class TestBlockHeaderSerialisation:
+    def _make_header(self, **overrides) -> BlockHeader:
+        defaults = dict(
+            version=1,
+            height=42,
+            timestamp=1_700_000_000,
+            previousBlockHash=bytes(range(32)),
+            previousRoot=bytes([0xAA] * 32),
+            outputRoot=bytes([0xBB] * 32),
+            rangeProofRoot=bytes([0xCC] * 32),
+            kernelRoot=bytes([0xDD] * 32),
+            totalKernelOffset=BlindingFactor(bytes([0x01] * 32)),
+            outputMMRSize=7,
+            kernelMMRSize=3,
+            totalDifficulty=1_234_567,
+            scalingDifficulty=511,
+            nonce=9_876_543_210,
+            proofOfWork=ProofOfWork(29, [0] * 42),
+        )
+        defaults.update(overrides)
+        return BlockHeader(**defaults)
+
+    def test_serialize_deserialize_roundtrip(self):
+        """Serialising and deserialising a header produces identical bytes."""
+        header = self._make_header()
+        s1 = Serializer()
+        header.serialize(s1)
+        original_bytes = s1.getvalue()
+
+        s2 = Serializer()
+        s2.write(original_bytes)
+        reconstructed = BlockHeader.deserialize(s2)
+
+        s3 = Serializer()
+        reconstructed.serialize(s3)
+        assert s1.getvalue() == s3.getvalue()
+
+    def test_version_preserved(self):
+        header = self._make_header(version=3)
+        s = Serializer()
+        header.serialize(s)
+        r = BlockHeader.deserialize(s)
+        assert r.getVersion() == 3
+
+    def test_height_preserved(self):
+        header = self._make_header(height=999_999)
+        s = Serializer()
+        header.serialize(s)
+        r = BlockHeader.deserialize(s)
+        assert r.getHeight() == 999_999
+
+    def test_hash_deterministic(self):
+        """Same header always produces the same hash."""
+        header = self._make_header()
+        assert header.getHash() == header.getHash()
+
+    def test_hash_differs_after_height_change(self):
+        h1 = self._make_header(height=1)
+        h2 = self._make_header(height=2)
+        assert h1.getHash() != h2.getHash()
+
+    def test_prepow_deterministic(self):
+        header = self._make_header()
+        assert header.getPrePoW() == header.getPrePoW()
+
+    def test_prepow_excludes_nonce(self):
+        """Pre-PoW bytes are the same regardless of nonce value."""
+        h1 = self._make_header(nonce=0)
+        h2 = self._make_header(nonce=0xFFFF_FFFF_FFFF_FFFF)
+        assert h1.getPrePoW() == h2.getPrePoW()
+
+
+# ---------------------------------------------------------------------------
+# CompactBlock serialisation round-trip
+# (mirrors serialize_deserialize_compact_block,
+#  empty_compact_block_serialized_size)
+# ---------------------------------------------------------------------------
+
+
+class TestCompactBlockSerialisation:
+    def test_empty_compact_block_serialize(self):
+        """CompactBlock with no outputs/kernels/shortids serialises cleanly."""
+        header = _dummy_header()
+        cb = CompactBlock(
+            header=header, nonce=42, fullOutputs=[], fullKernels=[], shortIds=[]
+        )
+        raw = cb.serialize()
+        # nonce(8) + counts(2+2+2) = 14 bytes minimum body
+        assert len(raw) >= 14
+
+    def test_nonce_preserved_in_body(self):
+        """Nonce is the first 8 bytes of CompactBlock body (big-endian)."""
+        header = _dummy_header()
+        nonce_val = 0xDEAD_BEEF_1234_5678
+        cb = CompactBlock(
+            header=header, nonce=nonce_val, fullOutputs=[], fullKernels=[], shortIds=[]
+        )
+        raw = cb.serialize()
+        parsed_nonce = int.from_bytes(raw[:8], "big")
+        assert parsed_nonce == nonce_val
+
+    def test_output_count_in_body(self):
+        """num_outputs (2 bytes) at offset 8 of CompactBlock body."""
+        header = _dummy_header()
+        cb = CompactBlock(
+            header=header,
+            nonce=0,
+            fullOutputs=[_plain_output(5)],
+            fullKernels=[],
+            shortIds=[],
+        )
+        raw = cb.serialize()
+        num_outputs = int.from_bytes(raw[8:10], "big")
+        assert num_outputs == 1

--- a/tests/test_chain_adapter_impl.py
+++ b/tests/test_chain_adapter_impl.py
@@ -1,3 +1,5 @@
+from io import BytesIO
+
 from mimblewimble.mmr.segment import SegmentType
 from mimblewimble.blockchain import BlockHeader, ProofOfWork
 from mimblewimble.models.transaction import BlindingFactor
@@ -27,6 +29,25 @@ def test_adapter_forwards_pibd_segments_to_active_handler():
         (SegmentType.RANGEPROOF, block_hash, "rangeproof"),
         (SegmentType.KERNEL, block_hash, "kernel"),
     ]
+
+
+def test_adapter_forwards_streamed_txhashset_to_active_handler():
+    adapter = ConcreteChainAdapter(genesis_hash=b"\x00" * 32)
+    received = []
+    block_hash = b"\x02" * 32
+    archive = b"zip-payload"
+
+    adapter.set_txhashset_stream_handler(
+        lambda received_hash, height, stream, size: received.append(
+            (received_hash, height, stream.read(), size)
+        )
+        or True
+    )
+
+    assert adapter.txhashset_write_stream(
+        block_hash, 7, BytesIO(archive), len(archive)
+    )
+    assert received == [(block_hash, 7, archive, len(archive))]
 
 
 def _make_header(height: int, total_difficulty: int) -> BlockHeader:

--- a/tests/test_chain_adapter_impl.py
+++ b/tests/test_chain_adapter_impl.py
@@ -1,0 +1,69 @@
+from mimblewimble.mmr.segment import SegmentType
+from mimblewimble.blockchain import BlockHeader, ProofOfWork
+from mimblewimble.models.transaction import BlindingFactor
+from mimblewimble.p2p.chain_adapter_impl import ConcreteChainAdapter
+from mimblewimble.pow.blockdb import SQLiteBlockDB
+
+
+def test_adapter_forwards_pibd_segments_to_active_handler():
+    adapter = ConcreteChainAdapter(genesis_hash=b"\x00" * 32)
+    received = []
+    block_hash = b"\x01" * 32
+
+    adapter.set_pibd_segment_handler(
+        lambda segment_type, received_hash, segment: received.append(
+            (segment_type, received_hash, segment)
+        )
+    )
+
+    adapter.receive_bitmap_segment(block_hash, "bitmap")
+    adapter.receive_output_segment(block_hash, "output")
+    adapter.receive_rangeproof_segment(block_hash, "rangeproof")
+    adapter.receive_kernel_segment(block_hash, "kernel")
+
+    assert received == [
+        (SegmentType.BITMAP, block_hash, "bitmap"),
+        (SegmentType.OUTPUT, block_hash, "output"),
+        (SegmentType.RANGEPROOF, block_hash, "rangeproof"),
+        (SegmentType.KERNEL, block_hash, "kernel"),
+    ]
+
+
+def _make_header(height: int, total_difficulty: int) -> BlockHeader:
+    return BlockHeader(
+        version=5,
+        height=height,
+        timestamp=1_000_000 + height,
+        previousBlockHash=b"\x00" * 32,
+        previousRoot=b"\x00" * 32,
+        outputRoot=b"\x00" * 32,
+        rangeProofRoot=b"\x00" * 32,
+        kernelRoot=b"\x00" * 32,
+        totalKernelOffset=BlindingFactor(b"\x00" * 32),
+        outputMMRSize=0,
+        kernelMMRSize=0,
+        totalDifficulty=total_difficulty,
+        scalingDifficulty=1,
+        nonce=height,
+        proofOfWork=ProofOfWork(29, [0] * 42),
+    )
+
+
+def test_sqlite_block_db_restores_adapter_tip_after_restart(tmp_path):
+    path = tmp_path / "chain.sqlite"
+    first = SQLiteBlockDB(path)
+    low_header = _make_header(height=4, total_difficulty=40)
+    best_header = _make_header(height=5, total_difficulty=50)
+    first.add_header(low_header)
+    first.add_header(best_header)
+    first.close()
+
+    restored = SQLiteBlockDB(path)
+    adapter = ConcreteChainAdapter(genesis_hash=b"\x00" * 32, block_db=restored)
+
+    assert restored.get_block_header(low_header.getHash().hex()).getHash() == low_header.getHash()
+    assert restored.get_header_by_height(5).getHash() == best_header.getHash()
+    assert adapter.best_height() == 5
+    assert adapter.total_difficulty() == 50
+    assert adapter.get_locator()[0] == best_header.getHash()
+    restored.close()

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1,10 +1,16 @@
 import socket
 import struct
 import threading
+from io import BytesIO
 
 import pytest
 
-from mimblewimble.p2p.connection import Connection, ConnectionError, MAX_BODY_BYTES
+from mimblewimble.p2p.connection import (
+    Connection,
+    ConnectionError,
+    MAX_ATTACHMENT_BYTES,
+    MAX_BODY_BYTES,
+)
 from mimblewimble.p2p.message import MAINNET_MAGIC, MessageType, pack_header
 
 
@@ -109,6 +115,61 @@ def test_recv_message_nonblocking_rejects_invalid_message_type():
 
         with pytest.raises(ConnectionError, match="Invalid message header"):
             conn.recv_message_nonblocking()
+    finally:
+        conn.close()
+        peer.close()
+
+
+def test_recv_message_with_attachment_preserves_next_message_boundary():
+    conn, peer = _socket_pair_connection()
+    try:
+        archive = b"PK\x03\x04archive"
+        metadata = b"\x11" * 32 + struct.pack(">QQ", 42, len(archive))
+        peer.sendall(pack_header(MessageType.TxHashSetArchive, metadata) + archive)
+        peer.sendall(pack_header(MessageType.Ping, b""))
+
+        msg_type, body, attachment = conn.recv_message_with_attachment()
+
+        assert msg_type == MessageType.TxHashSetArchive
+        assert body == metadata
+        assert attachment == archive
+        assert conn.recv_message() == (MessageType.Ping, b"")
+    finally:
+        conn.close()
+        peer.close()
+
+
+def test_recv_message_with_attachment_rejects_oversized_archive():
+    conn, peer = _socket_pair_connection()
+    try:
+        metadata = b"\x22" * 32 + struct.pack(">QQ", 42, MAX_ATTACHMENT_BYTES + 1)
+        peer.sendall(pack_header(MessageType.TxHashSetArchive, metadata))
+
+        with pytest.raises(ConnectionError, match="Attachment too large"):
+            conn.recv_message_with_attachment()
+    finally:
+        conn.close()
+        peer.close()
+
+
+def test_recv_message_with_attachment_streams_to_sink_and_preserves_boundary():
+    conn, peer = _socket_pair_connection()
+    try:
+        archive = b"archive-bytes" * 10000
+        metadata = b"\x44" * 32 + struct.pack(">QQ", 7, len(archive))
+        peer.sendall(pack_header(MessageType.TxHashSetArchive, metadata) + archive)
+        peer.sendall(pack_header(MessageType.Pong, b""))
+        sink = BytesIO()
+
+        msg_type, body, written = conn.recv_message_with_attachment_to(
+            sink, chunk_size=31
+        )
+
+        assert msg_type == MessageType.TxHashSetArchive
+        assert body == metadata
+        assert written == len(archive)
+        assert sink.getvalue() == archive
+        assert conn.recv_message() == (MessageType.Pong, b"")
     finally:
         conn.close()
         peer.close()

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -90,7 +90,7 @@ def test_recv_message_nonblocking_rejects_oversized_body_length():
     conn, peer = _socket_pair_connection()
     try:
         header = MAINNET_MAGIC + struct.pack(
-            "<IQ", int(MessageType.Ping), MAX_BODY_BYTES + 1
+            ">BQ", int(MessageType.Ping), MAX_BODY_BYTES + 1
         )
         peer.sendall(header)
 
@@ -104,7 +104,7 @@ def test_recv_message_nonblocking_rejects_oversized_body_length():
 def test_recv_message_nonblocking_rejects_invalid_message_type():
     conn, peer = _socket_pair_connection()
     try:
-        header = MAINNET_MAGIC + struct.pack("<IQ", 9999, 0)
+        header = MAINNET_MAGIC + struct.pack(">BQ", 255, 0)
         peer.sendall(header)
 
         with pytest.raises(ConnectionError, match="Invalid message header"):

--- a/tests/test_consensus.py
+++ b/tests/test_consensus.py
@@ -1,0 +1,279 @@
+"""
+tests/test_consensus.py
+
+Unit tests for mimblewimble/consensus.py.
+
+Mirrors the automated, mainnet, and testnet consensus test suites in:
+  grin/core/tests/consensus_automated.rs
+  grin/core/tests/consensus_mainnet.rs
+  grin/core/tests/consensus_testnet.rs
+"""
+
+import pytest
+
+from mimblewimble.consensus import Consensus
+
+
+# ---------------------------------------------------------------------------
+# Protocol constants
+# ---------------------------------------------------------------------------
+
+
+class TestConsensusConstants:
+    def test_proofsize(self):
+        assert Consensus.proofsize == 42
+
+    def test_max_block_weight(self):
+        assert Consensus.max_block_weight == 40_000
+
+    def test_coinbase_maturity(self):
+        # one day of blocks at 60-second block time = 1440 blocks
+        assert Consensus.coinbase_maturity == 1440
+
+    def test_block_time_sec(self):
+        assert Consensus.block_time_sec == 60
+
+    def test_default_min_edge_bits(self):
+        assert Consensus.default_min_edge_bits == 31
+
+    def test_second_pow_edge_bits(self):
+        assert Consensus.second_pow_edge_bits == 29
+
+    def test_base_edge_bits(self):
+        assert Consensus.base_edge_bits == 24
+
+    def test_reward(self):
+        # 60 Grin per second × 10^9 nanogrins/grin
+        assert Consensus.reward == 60_000_000_000
+
+    def test_year_height(self):
+        # 52 weeks × 7 days × 24 hours × 60 blocks/hour
+        assert Consensus.year_height == 524_160.0
+
+    def test_week_height(self):
+        assert Consensus.week_height == 10_080.0
+
+    def test_day_height(self):
+        assert Consensus.day_height == 1_440.0
+
+
+# ---------------------------------------------------------------------------
+# Block weight calculations (mirrors calculateWeightV4/V5 in consensus.rs)
+# ---------------------------------------------------------------------------
+
+
+class TestBlockWeightV4:
+    def test_empty_body(self):
+        assert Consensus.calculateWeightV4(0, 0, 0) == 0
+
+    def test_one_input_reduces_weight(self):
+        # V4: weight = -1 * inputs + 4 * outputs + 1 * kernels
+        assert Consensus.calculateWeightV4(1, 0, 0) == -1
+
+    def test_one_output(self):
+        assert Consensus.calculateWeightV4(0, 1, 0) == 4
+
+    def test_one_kernel(self):
+        assert Consensus.calculateWeightV4(0, 0, 1) == 1
+
+    def test_typical_tx(self):
+        # 2 inputs, 2 outputs, 1 kernel → -2 + 8 + 1 = 7
+        assert Consensus.calculateWeightV4(2, 2, 1) == 7
+
+
+class TestBlockWeightV5:
+    def test_empty_body(self):
+        assert Consensus.calculateWeightV5(0, 0, 0) == 0
+
+    def test_input_weight(self):
+        assert Consensus.calculateWeightV5(1, 0, 0) == Consensus.input_weight
+
+    def test_output_weight(self):
+        assert Consensus.calculateWeightV5(0, 1, 0) == Consensus.output_weight
+
+    def test_kernel_weight(self):
+        assert Consensus.calculateWeightV5(0, 0, 1) == Consensus.kernel_weight
+
+    def test_input_weight_value(self):
+        assert Consensus.input_weight == 1
+
+    def test_output_weight_value(self):
+        assert Consensus.output_weight == 21
+
+    def test_kernel_weight_value(self):
+        assert Consensus.kernel_weight == 3
+
+    def test_max_weight_exceeded_by_1905_outputs(self):
+        # 1905 × 21 = 40 005 > 40 000
+        weight = Consensus.calculateWeightV5(0, 1905, 0)
+        assert weight > Consensus.max_block_weight
+
+    def test_1904_outputs_within_limit(self):
+        # 1904 × 21 = 39 984 ≤ 40 000
+        weight = Consensus.calculateWeightV5(0, 1904, 0)
+        assert weight <= Consensus.max_block_weight
+
+    def test_max_block_weight_with_coinbase(self):
+        # A block with coinbase only: 0 inputs, 1 output, 1 kernel
+        # 21 + 3 = 24 — well within limit
+        assert Consensus.calculateWeightV5(0, 1, 1) == 24
+
+
+# ---------------------------------------------------------------------------
+# Primary / secondary PoW classification
+# ---------------------------------------------------------------------------
+
+
+class TestPrimarySecondaryPow:
+    def test_edge_bits_28_not_primary(self):
+        assert not Consensus.isPrimary(28)
+
+    def test_edge_bits_29_not_primary(self):
+        assert not Consensus.isPrimary(29)
+
+    def test_edge_bits_31_is_primary(self):
+        assert Consensus.isPrimary(31)
+
+    def test_edge_bits_32_is_primary(self):
+        assert Consensus.isPrimary(32)
+
+    def test_edge_bits_29_is_secondary(self):
+        assert Consensus.isSecondary(29)
+
+    def test_edge_bits_28_not_secondary(self):
+        assert not Consensus.isSecondary(28)
+
+    def test_edge_bits_30_not_secondary(self):
+        assert not Consensus.isSecondary(30)
+
+    def test_edge_bits_31_not_secondary(self):
+        assert not Consensus.isSecondary(31)
+
+
+# ---------------------------------------------------------------------------
+# Header version / hard fork schedule (mainnet)
+# hard_fork_interval ≈ 262 080 blocks (year_height / 2)
+# ---------------------------------------------------------------------------
+
+
+class TestHeaderVersionMainnet:
+    # Boundaries:  HF1 = 262080, HF2 = 524160, HF3 = 786240, HF4 = 1048320
+
+    def test_version_1_at_genesis(self):
+        assert Consensus.getHeaderVersion(0) == 1
+
+    def test_version_1_just_before_hf1(self):
+        assert Consensus.getHeaderVersion(262_079) == 1
+
+    def test_version_2_at_hf1(self):
+        assert Consensus.getHeaderVersion(262_080) == 2
+
+    def test_version_2_just_before_hf2(self):
+        assert Consensus.getHeaderVersion(524_159) == 2
+
+    def test_version_3_at_hf2(self):
+        assert Consensus.getHeaderVersion(524_160) == 3
+
+    def test_version_3_just_before_hf3(self):
+        assert Consensus.getHeaderVersion(786_239) == 3
+
+    def test_version_4_at_hf3(self):
+        assert Consensus.getHeaderVersion(786_240) == 4
+
+    def test_version_4_just_before_hf4(self):
+        assert Consensus.getHeaderVersion(1_048_319) == 4
+
+    def test_version_5_at_hf4(self):
+        assert Consensus.getHeaderVersion(1_048_320) == 5
+
+    def test_version_5_far_in_future(self):
+        assert Consensus.getHeaderVersion(10_000_000) == 5
+
+
+# ---------------------------------------------------------------------------
+# Header version / hard fork schedule (floonet / testnet)
+# ---------------------------------------------------------------------------
+
+
+class TestHeaderVersionFloonet:
+    def test_version_1_at_genesis(self):
+        assert Consensus.getHeaderVersion(0, testnet=True) == 1
+
+    def test_version_1_before_floonet_hf1(self):
+        assert Consensus.getHeaderVersion(185_039, testnet=True) == 1
+
+    def test_version_2_at_floonet_hf1(self):
+        assert Consensus.getHeaderVersion(185_040, testnet=True) == 2
+
+    def test_version_3_at_floonet_hf2(self):
+        assert Consensus.getHeaderVersion(298_080, testnet=True) == 3
+
+    def test_version_4_at_floonet_hf3(self):
+        assert Consensus.getHeaderVersion(552_960, testnet=True) == 4
+
+    def test_version_5_beyond_floonet_hf4(self):
+        assert Consensus.getHeaderVersion(642_240, testnet=True) == 5
+
+
+# ---------------------------------------------------------------------------
+# Secondary PoW ratio (decreases from 90 % to 0 % over two years)
+# ---------------------------------------------------------------------------
+
+
+class TestSecondaryPoWRatio:
+    def test_ratio_at_genesis_is_90(self):
+        assert Consensus.secondaryPOWRatio(0) == 90
+
+    def test_ratio_at_one_year_is_45(self):
+        ratio = Consensus.secondaryPOWRatio(int(Consensus.year_height))
+        assert ratio == 45
+
+    def test_ratio_at_two_years_is_zero(self):
+        ratio = Consensus.secondaryPOWRatio(int(2 * Consensus.year_height))
+        assert ratio == 0
+
+    def test_ratio_decreases_monotonically(self):
+        heights = [
+            0,
+            int(Consensus.year_height // 2),
+            int(Consensus.year_height),
+            int(Consensus.year_height * 3 // 2),
+            int(2 * Consensus.year_height),
+        ]
+        ratios = [Consensus.secondaryPOWRatio(h) for h in heights]
+        for i in range(len(ratios) - 1):
+            assert ratios[i] >= ratios[i + 1]
+
+    def test_ratio_never_negative(self):
+        # Even far beyond 2 years, ratio is clamped at 0
+        ratio = Consensus.secondaryPOWRatio(int(10 * Consensus.year_height))
+        assert ratio >= 0
+
+
+# ---------------------------------------------------------------------------
+# NRD kernel relative height bounds
+# (mirrors NRD validation in core/src/core/transaction.rs)
+# ---------------------------------------------------------------------------
+
+
+class TestNrdRelativeHeight:
+    def test_min_relative_height_is_1(self):
+        # Relative height 0 is invalid for NRD kernels
+        assert Consensus.week_height > 0
+
+    def test_max_relative_height_is_week_height(self):
+        # NRD relative height must be ≤ WEEK_HEIGHT
+        assert Consensus.week_height == 10_080.0
+
+    def test_relative_height_in_range(self):
+        # Valid range: [1, week_height]
+        valid = 1
+        assert 1 <= valid <= Consensus.week_height
+
+    def test_relative_height_zero_invalid(self):
+        invalid = 0
+        assert not (1 <= invalid <= Consensus.week_height)
+
+    def test_relative_height_too_large_invalid(self):
+        invalid = int(Consensus.week_height) + 1
+        assert not (1 <= invalid <= Consensus.week_height)

--- a/tests/test_fee_fields.py
+++ b/tests/test_fee_fields.py
@@ -1,0 +1,123 @@
+"""
+tests/test_fee_fields.py
+
+Unit tests for mimblewimble/models/fee.py (FeeFields).
+
+Mirrors the fee-field tests in:
+  grin/core/tests/transaction.rs :: test_fee_fields
+"""
+
+import pytest
+
+from mimblewimble.models.fee import Fee
+from mimblewimble.serializer import Serializer
+
+
+# ---------------------------------------------------------------------------
+# Basic constructors and accessors
+# ---------------------------------------------------------------------------
+
+
+class TestFeeConstructors:
+    def test_fromint_zero(self):
+        f = Fee.fromInt(0)
+        assert f.getFee() == 0
+        assert f.getShift() == 0
+
+    def test_fromint_nonzero(self):
+        f = Fee.fromInt(1_000_000)
+        assert f.getFee() == 1_000_000
+        assert f.getShift() == 0
+
+    def test_fromint_large_fee(self):
+        # Fee fits in 40 bits (max ~1 099 511 627 775)
+        large = 0xFF_FFFF_FFFF  # 40-bit max
+        f = Fee.fromInt(large)
+        assert f.getFee() == large
+
+    def test_constructor_shift_and_fee(self):
+        f = Fee(shift=3, fee=500_000)
+        assert f.getShift() == 3
+        assert f.getFee() == 500_000
+
+    def test_shift_max_nibble(self):
+        f = Fee(shift=15, fee=1)
+        assert f.getShift() == 15
+
+
+# ---------------------------------------------------------------------------
+# Serialise / deserialise round-trip  (mirrors FeeFields encode/decode in Rust)
+# ---------------------------------------------------------------------------
+
+
+class TestFeeSerialisation:
+    def _roundtrip(self, shift, fee):
+        original = Fee(shift=shift, fee=fee)
+        s = Serializer()
+        original.serialize(s)
+        reconstructed = Fee.deserialize(s)
+        return reconstructed
+
+    def test_zero_fee_roundtrip(self):
+        r = self._roundtrip(0, 0)
+        assert r.getFee() == 0
+        assert r.getShift() == 0
+
+    def test_nonzero_fee_roundtrip(self):
+        r = self._roundtrip(0, 7_000_000)
+        assert r.getFee() == 7_000_000
+        assert r.getShift() == 0
+
+    def test_shift_preserved_in_roundtrip(self):
+        r = self._roundtrip(3, 1_000_000)
+        assert r.getFee() == 1_000_000
+        assert r.getShift() == 3
+
+    def test_shift_max_nibble_roundtrip(self):
+        r = self._roundtrip(15, 100)
+        assert r.getShift() == 15
+        assert r.getFee() == 100
+
+    def test_shift_masked_to_4_bits(self):
+        # Only the low 4 bits of shift survive serialisation
+        original = Fee(shift=0x1F, fee=50)  # 5-bit value; only low 4 bits stored
+        s = Serializer()
+        original.serialize(s)
+        reconstructed = Fee.deserialize(s)
+        assert reconstructed.getShift() == (0x1F & 0x0F)
+
+    def test_serialised_length_is_8_bytes(self):
+        f = Fee(shift=1, fee=42)
+        s = Serializer()
+        f.serialize(s)
+        assert len(s.getvalue()) == 8
+
+    def test_large_fee_roundtrip(self):
+        large = 0xFF_FFFF_FFFF
+        r = self._roundtrip(0, large)
+        assert r.getFee() == large
+
+
+# ---------------------------------------------------------------------------
+# Equality
+# ---------------------------------------------------------------------------
+
+
+class TestFeeEquality:
+    def test_equal_fees(self):
+        a = Fee(0, 1_000)
+        b = Fee(0, 1_000)
+        assert a == b
+
+    def test_different_fee_amounts(self):
+        a = Fee(0, 1_000)
+        b = Fee(0, 2_000)
+        assert a != b
+
+    def test_different_shifts(self):
+        a = Fee(0, 1_000)
+        b = Fee(1, 1_000)
+        assert a != b
+
+    def test_zero_fees_equal(self):
+        assert Fee.fromInt(0) == Fee.fromInt(0)

--- a/tests/test_p2p_messages.py
+++ b/tests/test_p2p_messages.py
@@ -1,0 +1,479 @@
+"""
+tests/test_p2p_messages.py
+
+Unit tests for mimblewimble/p2p/message.py — P2P wire message serialisation.
+
+Mirrors the p2p round-trip tests in:
+  grin/p2p/tests/ser_deser.rs
+  grin/p2p/tests/capabilities.rs
+  grin/p2p/tests/peer_addr.rs
+  grin/p2p/tests/peer_handshake.rs
+"""
+
+import struct
+import pytest
+
+from mimblewimble.p2p.message import (
+    MAINNET_MAGIC,
+    TESTNET_MAGIC,
+    HEADER_LEN,
+    PROTOCOL_VERSION,
+    USER_AGENT,
+    MessageType,
+    Capabilities,
+    PeerAddr,
+    pack_header,
+    unpack_header,
+    _encode_str,
+    _decode_str,
+    MsgError,
+    MsgHand,
+    MsgShake,
+    MsgPing,
+    MsgPong,
+    MsgGetPeerAddrs,
+    MsgPeerAddrs,
+    MsgGetHeaders,
+    MsgHeaders,
+    MsgGetBlock,
+    MsgGetCompactBlock,
+    MsgTxHashSetRequest,
+    MsgTxHashSetArchive,
+    MsgBanReason,
+    MsgCompactBlock,
+)
+
+
+# ---------------------------------------------------------------------------
+# Magic bytes and frame header
+# ---------------------------------------------------------------------------
+
+
+class TestMagicAndFraming:
+    def test_mainnet_magic_bytes(self):
+        assert MAINNET_MAGIC == bytes([0x61, 0x3D])
+
+    def test_testnet_magic_bytes(self):
+        assert TESTNET_MAGIC == bytes([0x83, 0xC1])
+
+    def test_header_length_is_14(self):
+        assert HEADER_LEN == 14  # 2 magic + 4 type + 8 body_len
+
+    def test_pack_header_length(self):
+        body = b"\xde\xad\xbe\xef"
+        frame = pack_header(MessageType.Ping, body)
+        assert len(frame) == HEADER_LEN + len(body)
+
+    def test_pack_header_magic(self):
+        frame = pack_header(MessageType.Ping, b"")
+        assert frame[:2] == MAINNET_MAGIC
+
+    def test_pack_header_testnet_magic(self):
+        frame = pack_header(MessageType.Ping, b"", magic=TESTNET_MAGIC)
+        assert frame[:2] == TESTNET_MAGIC
+
+    def test_unpack_header_roundtrip(self):
+        body = b"\x01\x02\x03"
+        frame = pack_header(MessageType.Pong, body)
+        magic, msg_type, body_len = unpack_header(frame)
+        assert magic == MAINNET_MAGIC
+        assert msg_type == MessageType.Pong
+        assert body_len == len(body)
+
+    def test_unpack_header_too_short_raises(self):
+        with pytest.raises(ValueError):
+            unpack_header(b"\x61\x3d")
+
+    def test_pack_unpack_all_message_types(self):
+        for mt in MessageType:
+            body = b"\xff" * 4
+            frame = pack_header(mt, body)
+            _, parsed_type, body_len = unpack_header(frame)
+            assert parsed_type == mt
+            assert body_len == 4
+
+
+# ---------------------------------------------------------------------------
+# Capabilities bitmask (mirrors p2p/tests/capabilities.rs)
+# ---------------------------------------------------------------------------
+
+
+class TestCapabilities:
+    def test_unknown_is_zero(self):
+        assert int(Capabilities.UNKNOWN) == 0
+
+    def test_full_hist_is_bit_0(self):
+        assert int(Capabilities.FULL_HIST) == 1
+
+    def test_txhashset_hist_is_bit_1(self):
+        assert int(Capabilities.TXHASHSET_HIST) == 2
+
+    def test_peer_list_is_bit_2(self):
+        assert int(Capabilities.PEER_LIST) == 4
+
+    def test_tx_kernel_hash_is_bit_3(self):
+        assert int(Capabilities.TX_KERNEL_HASH) == 8
+
+    def test_pibd_hist_is_bit_4(self):
+        assert int(Capabilities.PIBD_HIST) == 16
+
+    def test_full_node_combines_base_caps(self):
+        expected = (
+            Capabilities.FULL_HIST
+            | Capabilities.TXHASHSET_HIST
+            | Capabilities.PEER_LIST
+            | Capabilities.TX_KERNEL_HASH
+            | Capabilities.PIBD_HIST
+        )
+        assert int(Capabilities.FULL_NODE) == int(expected)
+
+    def test_capabilities_bitwise_or(self):
+        combo = int(Capabilities.FULL_HIST) | int(Capabilities.PEER_LIST)
+        assert combo == 5
+
+    def test_capabilities_bitwise_and(self):
+        # Check that FULL_NODE contains PEER_LIST
+        assert int(Capabilities.FULL_NODE) & int(Capabilities.PEER_LIST) != 0
+
+    def test_unknown_not_in_full_node(self):
+        # UNKNOWN (0) is a sentinel, not in FULL_NODE
+        assert int(Capabilities.UNKNOWN) == 0
+
+
+# ---------------------------------------------------------------------------
+# PeerAddr (mirrors p2p/tests/peer_addr.rs)
+# ---------------------------------------------------------------------------
+
+
+class TestPeerAddr:
+    def _roundtrip(self, addr_str: str) -> PeerAddr:
+        pa = PeerAddr(addr=addr_str)
+        serialized = pa.serialize()
+        reconstructed, _ = PeerAddr.deserialize(serialized)
+        return reconstructed
+
+    def test_ipv4_addr_roundtrip(self):
+        r = self._roundtrip("127.0.0.1:3414")
+        assert r.addr == "127.0.0.1:3414"
+
+    def test_ipv6_addr_roundtrip(self):
+        r = self._roundtrip("[::1]:3414")
+        assert r.addr == "[::1]:3414"
+
+    def test_hostname_roundtrip(self):
+        r = self._roundtrip("node.example.com:3414")
+        assert r.addr == "node.example.com:3414"
+
+    def test_empty_addr_roundtrip(self):
+        r = self._roundtrip("")
+        assert r.addr == ""
+
+    def test_serialize_is_length_prefixed(self):
+        pa = PeerAddr(addr="a:1")
+        raw = pa.serialize()
+        (length,) = struct.unpack_from("<I", raw, 0)
+        assert length == len("a:1".encode())
+
+
+# ---------------------------------------------------------------------------
+# Individual message round-trips
+# ---------------------------------------------------------------------------
+
+
+def _body_of(full_frame: bytes) -> bytes:
+    return full_frame[HEADER_LEN:]
+
+
+class TestMsgError:
+    def test_roundtrip(self):
+        original = MsgError(message="something went wrong")
+        body = _body_of(original.serialize())
+        r = MsgError.deserialize(body)
+        assert r.message == original.message
+
+    def test_empty_message(self):
+        original = MsgError(message="")
+        body = _body_of(original.serialize())
+        r = MsgError.deserialize(body)
+        assert r.message == ""
+
+
+class TestMsgHand:
+    def _roundtrip(self, **kwargs) -> MsgHand:
+        original = MsgHand(**kwargs)
+        body = _body_of(original.serialize())
+        return MsgHand.deserialize(body)
+
+    def test_default_roundtrip(self):
+        r = self._roundtrip()
+        assert r.version == PROTOCOL_VERSION
+        assert r.user_agent == USER_AGENT
+
+    def test_custom_nonce(self):
+        r = self._roundtrip(nonce=0xDEADBEEF_CAFEBABE)
+        assert r.nonce == 0xDEADBEEF_CAFEBABE
+
+    def test_genesis_hash_preserved(self):
+        ghash = bytes(range(32))
+        r = self._roundtrip(genesis_hash=ghash)
+        assert r.genesis_hash == ghash
+
+    def test_sender_receiver_preserved(self):
+        r = self._roundtrip(sender_addr="1.2.3.4:3414", receiver_addr="5.6.7.8:3414")
+        assert r.sender_addr == "1.2.3.4:3414"
+        assert r.receiver_addr == "5.6.7.8:3414"
+
+    def test_capabilities_preserved(self):
+        r = self._roundtrip(capabilities=int(Capabilities.FULL_NODE))
+        assert r.capabilities == int(Capabilities.FULL_NODE)
+
+    def test_genesis_difficulty_preserved(self):
+        r = self._roundtrip(genesis_block_difficulty=999_999)
+        assert r.genesis_block_difficulty == 999_999
+
+    def test_msg_type_is_hand(self):
+        assert MsgHand.msg_type == MessageType.Hand
+
+
+class TestMsgShake:
+    def _roundtrip(self, **kwargs) -> MsgShake:
+        original = MsgShake(**kwargs)
+        body = _body_of(original.serialize())
+        return MsgShake.deserialize(body)
+
+    def test_default_roundtrip(self):
+        r = self._roundtrip()
+        assert r.version == PROTOCOL_VERSION
+
+    def test_genesis_hash_preserved(self):
+        ghash = bytes(range(32))
+        r = self._roundtrip(genesis_hash=ghash)
+        assert r.genesis_hash == ghash
+
+    def test_msg_type_is_shake(self):
+        assert MsgShake.msg_type == MessageType.Shake
+
+
+class TestMsgPingPong:
+    def test_ping_roundtrip(self):
+        original = MsgPing(total_difficulty=12345, height=99)
+        body = _body_of(original.serialize())
+        r = MsgPing.deserialize(body)
+        assert r.total_difficulty == 12345
+        assert r.height == 99
+
+    def test_pong_roundtrip(self):
+        original = MsgPong(total_difficulty=99999, height=42)
+        body = _body_of(original.serialize())
+        r = MsgPong.deserialize(body)
+        assert r.total_difficulty == 99999
+        assert r.height == 42
+
+    def test_ping_zero_values(self):
+        original = MsgPing(total_difficulty=0, height=0)
+        body = _body_of(original.serialize())
+        r = MsgPing.deserialize(body)
+        assert r.total_difficulty == 0
+        assert r.height == 0
+
+    def test_ping_msg_type(self):
+        assert MsgPing.msg_type == MessageType.Ping
+
+    def test_pong_msg_type(self):
+        assert MsgPong.msg_type == MessageType.Pong
+
+
+class TestMsgGetPeerAddrs:
+    def test_roundtrip(self):
+        original = MsgGetPeerAddrs(capabilities=int(Capabilities.FULL_NODE))
+        body = _body_of(original.serialize())
+        r = MsgGetPeerAddrs.deserialize(body)
+        assert r.capabilities == int(Capabilities.FULL_NODE)
+
+    def test_msg_type(self):
+        assert MsgGetPeerAddrs.msg_type == MessageType.GetPeerAddrs
+
+
+class TestMsgPeerAddrs:
+    def test_empty_peers_roundtrip(self):
+        original = MsgPeerAddrs(peers=[])
+        body = _body_of(original.serialize())
+        r = MsgPeerAddrs.deserialize(body)
+        assert r.peers == []
+
+    def test_single_peer_roundtrip(self):
+        original = MsgPeerAddrs(peers=[PeerAddr("10.0.0.1:3414")])
+        body = _body_of(original.serialize())
+        r = MsgPeerAddrs.deserialize(body)
+        assert len(r.peers) == 1
+        assert r.peers[0].addr == "10.0.0.1:3414"
+
+    def test_multiple_peers_roundtrip(self):
+        peers = [PeerAddr(f"10.0.0.{i}:3414") for i in range(5)]
+        original = MsgPeerAddrs(peers=peers)
+        body = _body_of(original.serialize())
+        r = MsgPeerAddrs.deserialize(body)
+        assert len(r.peers) == 5
+        assert [p.addr for p in r.peers] == [p.addr for p in peers]
+
+    def test_msg_type(self):
+        assert MsgPeerAddrs.msg_type == MessageType.PeerAddrs
+
+
+class TestMsgGetHeaders:
+    def test_empty_locator_roundtrip(self):
+        original = MsgGetHeaders(locator=[])
+        body = _body_of(original.serialize())
+        r = MsgGetHeaders.deserialize(body)
+        assert r.locator == []
+
+    def test_single_hash_roundtrip(self):
+        h = bytes(range(32))
+        original = MsgGetHeaders(locator=[h])
+        body = _body_of(original.serialize())
+        r = MsgGetHeaders.deserialize(body)
+        assert len(r.locator) == 1
+        assert r.locator[0] == h
+
+    def test_multiple_hashes_roundtrip(self):
+        hashes = [bytes([i] * 32) for i in range(5)]
+        original = MsgGetHeaders(locator=hashes)
+        body = _body_of(original.serialize())
+        r = MsgGetHeaders.deserialize(body)
+        assert len(r.locator) == 5
+        for i, h in enumerate(r.locator):
+            assert h == hashes[i]
+
+    def test_msg_type(self):
+        assert MsgGetHeaders.msg_type == MessageType.GetHeaders
+
+
+class TestMsgGetBlock:
+    def test_roundtrip(self):
+        block_hash = bytes(range(32))
+        original = MsgGetBlock(block_hash=block_hash)
+        body = _body_of(original.serialize())
+        r = MsgGetBlock.deserialize(body)
+        assert r.block_hash == block_hash
+
+    def test_msg_type(self):
+        assert MsgGetBlock.msg_type == MessageType.GetBlock
+
+
+class TestMsgGetCompactBlock:
+    def test_roundtrip(self):
+        block_hash = bytes([0xAB] * 32)
+        original = MsgGetCompactBlock(block_hash=block_hash)
+        body = _body_of(original.serialize())
+        r = MsgGetCompactBlock.deserialize(body)
+        assert r.block_hash == block_hash
+
+    def test_msg_type(self):
+        assert MsgGetCompactBlock.msg_type == MessageType.GetCompactBlock
+
+
+class TestMsgTxHashSet:
+    def test_request_roundtrip(self):
+        block_hash = bytes([0x11] * 32)
+        original = MsgTxHashSetRequest(block_hash=block_hash, height=12345)
+        body = _body_of(original.serialize())
+        r = MsgTxHashSetRequest.deserialize(body)
+        assert r.block_hash == block_hash
+        assert r.height == 12345
+
+    def test_archive_roundtrip(self):
+        block_hash = bytes([0x22] * 32)
+        zip_data = b"PK\x03\x04" + b"\xbe\xef" * 20
+        original = MsgTxHashSetArchive(
+            block_hash=block_hash, height=999, zip_bytes=zip_data
+        )
+        body = _body_of(original.serialize())
+        r = MsgTxHashSetArchive.deserialize(body)
+        assert r.block_hash == block_hash
+        assert r.height == 999
+        assert r.zip_bytes == zip_data
+
+    def test_archive_empty_zip(self):
+        original = MsgTxHashSetArchive(block_hash=b"\x00" * 32, height=0, zip_bytes=b"")
+        body = _body_of(original.serialize())
+        r = MsgTxHashSetArchive.deserialize(body)
+        assert r.zip_bytes == b""
+
+
+class TestMsgBanReason:
+    def test_roundtrip(self):
+        original = MsgBanReason(ban_reason="too many errors")
+        body = _body_of(original.serialize())
+        r = MsgBanReason.deserialize(body)
+        assert r.ban_reason == "too many errors"
+
+    def test_msg_type(self):
+        assert MsgBanReason.msg_type == MessageType.BanReason
+
+
+class TestMsgCompactBlock:
+    def test_roundtrip_raw_body(self):
+        """Compact block stores raw bytes; roundtrip preserves them."""
+        raw = b"\xde\xad\xbe\xef" * 16
+        original = MsgCompactBlock(raw_body=raw)
+        body = _body_of(original.serialize())
+        r = MsgCompactBlock.deserialize(body)
+        assert r.raw_body == raw
+
+    def test_empty_raw_body(self):
+        original = MsgCompactBlock(raw_body=b"")
+        body = _body_of(original.serialize())
+        r = MsgCompactBlock.deserialize(body)
+        assert r.raw_body == b""
+
+    def test_msg_type(self):
+        assert MsgCompactBlock.msg_type == MessageType.CompactBlock
+
+
+# ---------------------------------------------------------------------------
+# Message type enum values (mirrors Grin's Type enum in msg.rs)
+# ---------------------------------------------------------------------------
+
+
+class TestMessageTypeValues:
+    def test_error_is_0(self):
+        assert MessageType.Error == 0
+
+    def test_hand_is_1(self):
+        assert MessageType.Hand == 1
+
+    def test_shake_is_2(self):
+        assert MessageType.Shake == 2
+
+    def test_ping_is_3(self):
+        assert MessageType.Ping == 3
+
+    def test_pong_is_4(self):
+        assert MessageType.Pong == 4
+
+    def test_get_peer_addrs_is_5(self):
+        assert MessageType.GetPeerAddrs == 5
+
+    def test_peer_addrs_is_6(self):
+        assert MessageType.PeerAddrs == 6
+
+    def test_get_headers_is_7(self):
+        assert MessageType.GetHeaders == 7
+
+    def test_headers_is_8(self):
+        assert MessageType.Headers == 8
+
+    def test_get_block_is_9(self):
+        assert MessageType.GetBlock == 9
+
+    def test_block_is_10(self):
+        assert MessageType.Block == 10
+
+    def test_compact_block_is_12(self):
+        assert MessageType.CompactBlock == 12
+
+    def test_stem_transaction_is_13(self):
+        assert MessageType.StemTransaction == 13
+
+    def test_transaction_is_14(self):
+        assert MessageType.Transaction == 14

--- a/tests/test_p2p_messages.py
+++ b/tests/test_p2p_messages.py
@@ -50,14 +50,17 @@ from mimblewimble.p2p.message import (
 
 
 class TestMagicAndFraming:
+    def test_protocol_version_matches_current_grin(self):
+        assert PROTOCOL_VERSION == 1000
+
     def test_mainnet_magic_bytes(self):
         assert MAINNET_MAGIC == bytes([0x61, 0x3D])
 
     def test_testnet_magic_bytes(self):
         assert TESTNET_MAGIC == bytes([0x83, 0xC1])
 
-    def test_header_length_is_14(self):
-        assert HEADER_LEN == 14  # 2 magic + 4 type + 8 body_len
+    def test_header_length_is_11(self):
+        assert HEADER_LEN == 11  # 2 magic + 1 type + 8 body_len
 
     def test_pack_header_length(self):
         body = b"\xde\xad\xbe\xef"
@@ -117,6 +120,12 @@ class TestCapabilities:
     def test_pibd_hist_is_bit_4(self):
         assert int(Capabilities.PIBD_HIST) == 16
 
+    def test_block_hist_is_bit_5(self):
+        assert int(Capabilities.BLOCK_HIST) == 32
+
+    def test_pibd_hist_1_is_bit_6(self):
+        assert int(Capabilities.PIBD_HIST_1) == 64
+
     def test_full_node_combines_base_caps(self):
         expected = (
             Capabilities.FULL_HIST
@@ -124,6 +133,7 @@ class TestCapabilities:
             | Capabilities.PEER_LIST
             | Capabilities.TX_KERNEL_HASH
             | Capabilities.PIBD_HIST
+            | Capabilities.PIBD_HIST_1
         )
         assert int(Capabilities.FULL_NODE) == int(expected)
 
@@ -160,19 +170,22 @@ class TestPeerAddr:
         r = self._roundtrip("[::1]:3414")
         assert r.addr == "[::1]:3414"
 
-    def test_hostname_roundtrip(self):
-        r = self._roundtrip("node.example.com:3414")
-        assert r.addr == "node.example.com:3414"
+    def test_hostname_is_not_a_wire_peer_address(self):
+        with pytest.raises(ValueError):
+            PeerAddr(addr="node.example.com:3414").serialize()
 
-    def test_empty_addr_roundtrip(self):
-        r = self._roundtrip("")
-        assert r.addr == ""
+    def test_empty_address_is_not_a_wire_peer_address(self):
+        with pytest.raises(ValueError):
+            PeerAddr(addr="").serialize()
 
     def test_serialize_is_length_prefixed(self):
         pa = PeerAddr(addr="a:1")
-        raw = pa.serialize()
-        (length,) = struct.unpack_from("<I", raw, 0)
-        assert length == len("a:1".encode())
+        with pytest.raises(ValueError):
+            pa.serialize()
+
+    def test_serialize_uses_grin_ipv4_socket_address_layout(self):
+        raw = PeerAddr(addr="127.0.0.1:3414").serialize()
+        assert raw == b"\x00\x7f\x00\x00\x01\x0dV"
 
 
 # ---------------------------------------------------------------------------
@@ -255,6 +268,14 @@ class TestMsgShake:
 
 
 class TestMsgPingPong:
+    def test_ping_uses_big_endian_wire_values(self):
+        body = _body_of(MsgPing(total_difficulty=0x0102030405060708, height=9).serialize())
+        assert body == bytes.fromhex("01020304050607080000000000000009")
+
+    def test_pong_uses_big_endian_wire_values(self):
+        body = _body_of(MsgPong(total_difficulty=9, height=0x0102030405060708).serialize())
+        assert body == bytes.fromhex("00000000000000090102030405060708")
+
     def test_ping_roundtrip(self):
         original = MsgPing(total_difficulty=12345, height=99)
         body = _body_of(original.serialize())
@@ -284,6 +305,10 @@ class TestMsgPingPong:
 
 
 class TestMsgGetPeerAddrs:
+    def test_wire_capabilities_are_big_endian(self):
+        body = _body_of(MsgGetPeerAddrs(capabilities=0x01020304).serialize())
+        assert body == bytes.fromhex("01020304")
+
     def test_roundtrip(self):
         original = MsgGetPeerAddrs(capabilities=int(Capabilities.FULL_NODE))
         body = _body_of(original.serialize())
@@ -295,6 +320,10 @@ class TestMsgGetPeerAddrs:
 
 
 class TestMsgPeerAddrs:
+    def test_wire_peer_count_is_big_endian(self):
+        body = _body_of(MsgPeerAddrs(peers=[PeerAddr("10.0.0.1:3414")]).serialize())
+        assert body == bytes.fromhex("00000001000a0000010d56")
+
     def test_empty_peers_roundtrip(self):
         original = MsgPeerAddrs(peers=[])
         body = _body_of(original.serialize())
@@ -321,6 +350,10 @@ class TestMsgPeerAddrs:
 
 
 class TestMsgGetHeaders:
+    def test_wire_locator_count_is_a_single_byte(self):
+        body = _body_of(MsgGetHeaders(locator=[bytes.fromhex("ab" * 32)]).serialize())
+        assert body == b"\x01" + bytes.fromhex("ab" * 32)
+
     def test_empty_locator_roundtrip(self):
         original = MsgGetHeaders(locator=[])
         body = _body_of(original.serialize())
@@ -373,6 +406,12 @@ class TestMsgGetCompactBlock:
 
 
 class TestMsgTxHashSet:
+    def test_request_uses_big_endian_height(self):
+        body = _body_of(
+            MsgTxHashSetRequest(block_hash=b"\x11" * 32, height=0x0102030405060708).serialize()
+        )
+        assert body == b"\x11" * 32 + bytes.fromhex("0102030405060708")
+
     def test_request_roundtrip(self):
         block_hash = bytes([0x11] * 32)
         original = MsgTxHashSetRequest(block_hash=block_hash, height=12345)
@@ -391,13 +430,25 @@ class TestMsgTxHashSet:
         r = MsgTxHashSetArchive.deserialize(body)
         assert r.block_hash == block_hash
         assert r.height == 999
-        assert r.zip_bytes == zip_data
+        assert r.zip_bytes == b""
+        assert r.bytes_len == len(zip_data)
 
     def test_archive_empty_zip(self):
         original = MsgTxHashSetArchive(block_hash=b"\x00" * 32, height=0, zip_bytes=b"")
         body = _body_of(original.serialize())
         r = MsgTxHashSetArchive.deserialize(body)
         assert r.zip_bytes == b""
+        assert r.bytes_len == 0
+
+    def test_archive_frame_contains_only_big_endian_metadata(self):
+        body = _body_of(
+            MsgTxHashSetArchive(
+                block_hash=b"\x22" * 32,
+                height=0x0102030405060708,
+                zip_bytes=b"archive",
+            ).serialize()
+        )
+        assert body == b"\x22" * 32 + bytes.fromhex("01020304050607080000000000000007")
 
 
 class TestMsgBanReason:
@@ -460,20 +511,43 @@ class TestMessageTypeValues:
     def test_get_headers_is_7(self):
         assert MessageType.GetHeaders == 7
 
-    def test_headers_is_8(self):
-        assert MessageType.Headers == 8
+    def test_header_is_8(self):
+        assert MessageType.Header == 8
 
-    def test_get_block_is_9(self):
-        assert MessageType.GetBlock == 9
+    def test_headers_is_9(self):
+        assert MessageType.Headers == 9
 
-    def test_block_is_10(self):
-        assert MessageType.Block == 10
+    def test_get_block_is_10(self):
+        assert MessageType.GetBlock == 10
+
+    def test_block_is_11(self):
+        assert MessageType.Block == 11
 
     def test_compact_block_is_12(self):
-        assert MessageType.CompactBlock == 12
+        assert MessageType.GetCompactBlock == 12
 
-    def test_stem_transaction_is_13(self):
-        assert MessageType.StemTransaction == 13
+    def test_compact_block_is_13(self):
+        assert MessageType.CompactBlock == 13
 
-    def test_transaction_is_14(self):
-        assert MessageType.Transaction == 14
+    def test_stem_transaction_is_14(self):
+        assert MessageType.StemTransaction == 14
+
+    def test_transaction_is_15(self):
+        assert MessageType.Transaction == 15
+
+    def test_message_types_after_transaction_match_grin_wire_protocol(self):
+        assert [
+            MessageType.TxHashSetRequest,
+            MessageType.TxHashSetArchive,
+            MessageType.BanReason,
+            MessageType.GetTransaction,
+            MessageType.TransactionKernel,
+            MessageType.GetOutputBitmapSegment,
+            MessageType.OutputBitmapSegment,
+            MessageType.GetOutputSegment,
+            MessageType.OutputSegment,
+            MessageType.GetRangeProofSegment,
+            MessageType.RangeProofSegment,
+            MessageType.GetKernelSegment,
+            MessageType.KernelSegment,
+        ] == list(range(16, 29))

--- a/tests/test_p2p_messages.py
+++ b/tests/test_p2p_messages.py
@@ -13,6 +13,7 @@ Mirrors the p2p round-trip tests in:
 import struct
 import pytest
 
+from mimblewimble.genesis import mainnet
 from mimblewimble.p2p.message import (
     MAINNET_MAGIC,
     TESTNET_MAGIC,
@@ -41,7 +42,27 @@ from mimblewimble.p2p.message import (
     MsgTxHashSetArchive,
     MsgBanReason,
     MsgCompactBlock,
+    MsgOutputSegment,
+    MsgRangeProofSegment,
+    MsgKernelSegment,
 )
+from mimblewimble.serializer import Serializer
+
+
+@pytest.mark.parametrize(
+    "message_type",
+    [MsgOutputSegment, MsgRangeProofSegment, MsgKernelSegment],
+)
+def test_empty_segment_response_roundtrip(message_type):
+    block_hash = bytes.fromhex("ab" * 32)
+    message = message_type(block_hash=block_hash)
+    _, msg_type, body_length = unpack_header(message.serialize())
+    body = message.serialize()[-body_length:]
+
+    assert msg_type == message.msg_type
+    parsed = message_type.deserialize(body)
+    assert parsed.block_hash == block_hash
+    assert parsed.segment is None
 
 
 # ---------------------------------------------------------------------------
@@ -379,6 +400,32 @@ class TestMsgGetHeaders:
 
     def test_msg_type(self):
         assert MsgGetHeaders.msg_type == MessageType.GetHeaders
+
+
+class TestMsgHeaders:
+    @staticmethod
+    def _serialized_header() -> bytes:
+        serializer = Serializer()
+        mainnet.getHeader().serialize(serializer)
+        return serializer.getvalue()
+
+    def test_wire_layout_is_big_endian_count_followed_by_headers(self):
+        raw_header = self._serialized_header()
+        body = _body_of(MsgHeaders(headers=[raw_header]).serialize())
+
+        assert body == b"\x00\x01" + raw_header
+
+    def test_multiple_headers_are_concatenated_without_length_prefixes(self):
+        raw_header = self._serialized_header()
+        body = _body_of(MsgHeaders(headers=[raw_header, raw_header]).serialize())
+
+        assert body == b"\x00\x02" + raw_header + raw_header
+        assert MsgHeaders.deserialize(body).headers == [raw_header, raw_header]
+
+    def test_truncated_header_is_rejected(self):
+        raw_header = self._serialized_header()
+        with pytest.raises(ValueError, match="Malformed serialised block header"):
+            MsgHeaders.deserialize(b"\x00\x01" + raw_header[:-1])
 
 
 class TestMsgGetBlock:

--- a/tests/test_peer_dispatch.py
+++ b/tests/test_peer_dispatch.py
@@ -1,5 +1,9 @@
 import struct
+from typing import cast
 
+from mimblewimble.p2p.adapter import ChainAdapter
+from mimblewimble.p2p.connection import Connection
+from mimblewimble.p2p.handshake import HandshakeResult
 from mimblewimble.p2p.message import MessageType
 from mimblewimble.p2p.peer import Peer
 from mimblewimble.p2p.peers import NodeStorageInMemory, PeerStore
@@ -63,9 +67,9 @@ def test_peer_dispatch_headers_persists_via_peer_store():
     peers = PeerStore(node_storage=storage)
 
     peer = Peer(
-        conn=_FakeConn(),
-        handshake=_FakeHandshake(),
-        adapter=adapter,
+        conn=cast(Connection, _FakeConn()),
+        handshake=cast(HandshakeResult, _FakeHandshake()),
+        adapter=cast(ChainAdapter, adapter),
         peer_store=peers,
     )
 
@@ -77,3 +81,24 @@ def test_peer_dispatch_headers_persists_via_peer_store():
     stored = peers.get_headers()
     assert len(stored) == 2
     assert {stored[0].raw, stored[1].raw} == {h1, h2}
+
+
+def test_peer_dispatch_single_header_persists_via_peer_store():
+    adapter = _Adapter()
+    storage = NodeStorageInMemory()
+    peers = PeerStore(node_storage=storage)
+
+    peer = Peer(
+        conn=cast(Connection, _FakeConn()),
+        handshake=cast(HandshakeResult, _FakeHandshake()),
+        adapter=cast(ChainAdapter, adapter),
+        peer_store=peers,
+    )
+
+    raw_header = b"single-header"
+    peer._dispatch(MessageType.Header, raw_header)
+
+    assert adapter.headers == [raw_header]
+    stored = peers.get_headers()
+    assert len(stored) == 1
+    assert stored[0].raw == raw_header

--- a/tests/test_peer_dispatch.py
+++ b/tests/test_peer_dispatch.py
@@ -4,9 +4,11 @@ from typing import cast
 from mimblewimble.p2p.adapter import ChainAdapter
 from mimblewimble.p2p.connection import Connection
 from mimblewimble.p2p.handshake import HandshakeResult
-from mimblewimble.p2p.message import MessageType
+from mimblewimble.p2p.message import MessageType, MsgHeaders
 from mimblewimble.p2p.peer import Peer
 from mimblewimble.p2p.peers import NodeStorageInMemory, PeerStore
+from mimblewimble.genesis import mainnet
+from mimblewimble.serializer import Serializer
 
 
 class _FakeConn:
@@ -34,11 +36,18 @@ class _FakeHandshake:
 class _Adapter:
     def __init__(self):
         self.headers = []
+        self.txhashset_archives = []
 
     def sync_block_headers(self, raw_headers):
         self.headers.extend(raw_headers)
 
     def txhashset_write(self, block_hash: bytes, height: int, zip_bytes: bytes):
+        self.txhashset_archives.append((block_hash, height, zip_bytes))
+        return True
+
+    def txhashset_write_stream(self, block_hash, height, archive, size):
+        self.txhashset_archives.append((block_hash, height, archive.read()))
+        assert size == len(self.txhashset_archives[-1][2])
         return True
 
     def receive_bitmap_segment(self, block_hash: bytes, segment):
@@ -55,10 +64,16 @@ class _Adapter:
 
 
 def _headers_body(headers: list[bytes]) -> bytes:
-    body = struct.pack("<I", len(headers))
-    for header in headers:
-        body += struct.pack("<I", len(header)) + header
-    return body
+    return MsgHeaders(headers=headers).serialize()[11:]
+
+
+def _header_bytes(height_delta: int = 0) -> bytes:
+    header = mainnet.getHeader()
+    serializer = Serializer()
+    header.serialize(serializer)
+    raw = bytearray(serializer.getvalue())
+    raw[9] = (raw[9] + height_delta) % 256
+    return bytes(raw)
 
 
 def test_peer_dispatch_headers_persists_via_peer_store():
@@ -73,8 +88,8 @@ def test_peer_dispatch_headers_persists_via_peer_store():
         peer_store=peers,
     )
 
-    h1 = b"header-1"
-    h2 = b"header-2"
+    h1 = _header_bytes()
+    h2 = _header_bytes(1)
     peer._dispatch(MessageType.Headers, _headers_body([h1, h2]))
 
     assert adapter.headers == [h1, h2]
@@ -102,3 +117,19 @@ def test_peer_dispatch_single_header_persists_via_peer_store():
     stored = peers.get_headers()
     assert len(stored) == 1
     assert stored[0].raw == raw_header
+
+
+def test_peer_dispatch_txhashset_archive_passes_streamed_attachment():
+    adapter = _Adapter()
+    peer = Peer(
+        conn=cast(Connection, _FakeConn()),
+        handshake=cast(HandshakeResult, _FakeHandshake()),
+        adapter=cast(ChainAdapter, adapter),
+    )
+    block_hash = b"\x33" * 32
+    attachment = b"PK\x03\x04archive"
+    metadata = block_hash + struct.pack(">QQ", 42, len(attachment))
+
+    peer._dispatch(MessageType.TxHashSetArchive, metadata, attachment)
+
+    assert adapter.txhashset_archives == [(block_hash, 42, attachment)]

--- a/tests/test_pibd_live.py
+++ b/tests/test_pibd_live.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import json
 
-from mimblewimble.p2p.message import MessageType, MsgHeaders
+from mimblewimble.p2p.message import HEADER_LEN, MessageType, MsgHeaders
 
 
 def node_api(method: str, params=None, base_url: str = "http://mocked-node:3413"):
@@ -91,7 +91,7 @@ def test_parse_headers_message_from_mocked_p2p_payload():
     raw_headers = [b"hdr-1", b"hdr-2", b"hdr-3"]
     msg = MsgHeaders(headers=raw_headers)
 
-    message_type, body = MessageType.Headers, msg.serialize()[14:]
+    message_type, body = MessageType.Headers, msg.serialize()[HEADER_LEN:]
     assert message_type == MessageType.Headers
 
     parsed = MsgHeaders.deserialize(body)

--- a/tests/test_pibd_live.py
+++ b/tests/test_pibd_live.py
@@ -88,7 +88,12 @@ def test_get_header_uses_mocked_jsonrpc(monkeypatch):
 
 
 def test_parse_headers_message_from_mocked_p2p_payload():
-    raw_headers = [b"hdr-1", b"hdr-2", b"hdr-3"]
+    from mimblewimble.genesis import mainnet
+    from mimblewimble.serializer import Serializer
+
+    serializer = Serializer()
+    mainnet.getHeader().serialize(serializer)
+    raw_headers = [serializer.getvalue()]
     msg = MsgHeaders(headers=raw_headers)
 
     message_type, body = MessageType.Headers, msg.serialize()[HEADER_LEN:]

--- a/tests/test_pibd_snapshot.py
+++ b/tests/test_pibd_snapshot.py
@@ -55,13 +55,23 @@ def build_and_zip_txhashset(tmp_dir: Path, n_outputs: int, n_kernels: int):
 
 
 class _FakeHeader:
-    def __init__(self, output_mmr_size, kernel_mmr_size):
+    def __init__(self, output_mmr_size, kernel_mmr_size, roots=None):
         self.height = 1
         self.outputMMRSize = output_mmr_size
         self.kernelMMRSize = kernel_mmr_size
+        self._roots = roots or (b"\x00" * 32,) * 3
 
     def getHash(self):
         return b"\xab" * 32
+
+    def getOutputRoot(self):
+        return self._roots[0]
+
+    def getRangeProofRoot(self):
+        return self._roots[1]
+
+    def getKernelRoot(self):
+        return self._roots[2]
 
 
 def _build_txhashset_zip_bytes(txhs_dir: Path) -> bytes:
@@ -109,9 +119,68 @@ def test_snapshot_accepted_with_correct_roots(tmp_path):
     assert result is True
     snapshot_dir = tmp_path / "data" / f"_snapshot_{'ab' * 8}"
     assert not (snapshot_dir / "snapshot.zip").exists()
-    assert len(state_sync._peers.stored_blocks) == 1
-    assert state_sync._peers.stored_blocks[0].hash_hex == (b"\xab" * 32).hex()
-    assert len(state_sync._peers.stored_outputs) > 0
+    peers = cast(Any, state_sync._peers)
+    assert len(peers.stored_blocks) == 1
+    assert peers.stored_blocks[0].hash_hex == (b"\xab" * 32).hex()
+    assert len(peers.stored_outputs) > 0
+    txhs.close()
+
+
+def test_streamed_snapshot_is_validated_from_disk_and_cleaned_up(tmp_path):
+    src_dir = tmp_path / "stream_src"
+    src_dir.mkdir()
+    zip_bytes, out_root, rp_root, kern_root = build_and_zip_txhashset(
+        src_dir, n_outputs=2, n_kernels=1
+    )
+
+    txhs = TxHashSet(tmp_path / "stream_live")
+    state_sync = _make_state_sync(tmp_path, txhs)
+    state_sync._archive_header = _FakeHeader(
+        txhs.output_pmmr.size(), txhs.kernel_mmr.size(), (out_root, rp_root, kern_root)
+    )
+
+    assert state_sync.receive_txhashset_stream(
+        b"\xab" * 32, 1, io.BytesIO(zip_bytes), len(zip_bytes)
+    )
+    assert not (tmp_path / "data" / "_snapshot_abababababababab.zip").exists()
+    assert txhs.output_pmmr.root() == out_root
+    assert txhs.rangeproof_pmmr.root() == rp_root
+    assert txhs.kernel_mmr.root() == kern_root
+    txhs.close()
+
+
+def test_streamed_snapshot_root_mismatch_preserves_live_state(tmp_path):
+    src_dir = tmp_path / "mismatch_src"
+    src_dir.mkdir()
+    zip_bytes, out_root, rp_root, kern_root = build_and_zip_txhashset(
+        src_dir, n_outputs=2, n_kernels=1
+    )
+
+    txhs = TxHashSet(tmp_path / "mismatch_live")
+    txhs.output_pmmr.push(b"l" * 33)
+    txhs.rangeproof_pmmr.push(b"r" * 32)
+    txhs.kernel_mmr.push(b"k" * 32)
+    txhs.flush()
+    live_roots = (
+        txhs.output_pmmr.root(),
+        txhs.rangeproof_pmmr.root(),
+        txhs.kernel_mmr.root(),
+    )
+    state_sync = _make_state_sync(tmp_path, txhs)
+    state_sync._archive_header = _FakeHeader(
+        txhs.output_pmmr.size(), txhs.kernel_mmr.size(), (b"\xff" * 32, rp_root, kern_root)
+    )
+
+    with pytest.raises(StateSyncError, match="Snapshot PMMR roots"):
+        state_sync.receive_txhashset_stream(
+            b"\xab" * 32, 1, io.BytesIO(zip_bytes), len(zip_bytes)
+        )
+
+    assert (
+        txhs.output_pmmr.root(),
+        txhs.rangeproof_pmmr.root(),
+        txhs.kernel_mmr.root(),
+    ) == live_roots
     txhs.close()
 
 

--- a/tests/test_pibd_snapshot.py
+++ b/tests/test_pibd_snapshot.py
@@ -126,6 +126,30 @@ def test_snapshot_accepted_with_correct_roots(tmp_path):
     txhs.close()
 
 
+def test_snapshot_rejected_with_wrong_mmr_size(tmp_path):
+    src_dir = tmp_path / "size_src"
+    src_dir.mkdir()
+    zip_bytes, out_root, rp_root, kern_root = build_and_zip_txhashset(
+        src_dir, n_outputs=2, n_kernels=1
+    )
+
+    txhs = TxHashSet(tmp_path / "size_live")
+    state_sync = _make_state_sync(tmp_path, txhs)
+
+    with pytest.raises(StateSyncError, match="output MMR size mismatch"):
+        state_sync.apply_snapshot(
+            block_hash=b"\xab" * 32,
+            height=1,
+            zip_bytes=zip_bytes,
+            expected_output_root=out_root,
+            expected_rangeproof_root=rp_root,
+            expected_kernel_root=kern_root,
+            expected_output_mmr_size=1,
+            expected_kernel_mmr_size=1,
+        )
+    txhs.close()
+
+
 def test_streamed_snapshot_is_validated_from_disk_and_cleaned_up(tmp_path):
     src_dir = tmp_path / "stream_src"
     src_dir.mkdir()

--- a/tests/test_pibd_snapshot.py
+++ b/tests/test_pibd_snapshot.py
@@ -146,6 +146,7 @@ def test_streamed_snapshot_is_validated_from_disk_and_cleaned_up(tmp_path):
     assert txhs.output_pmmr.root() == out_root
     assert txhs.rangeproof_pmmr.root() == rp_root
     assert txhs.kernel_mmr.root() == kern_root
+    assert state_sync._sync_state.status.name == "BODY_SYNC"
     txhs.close()
 
 

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -1,0 +1,337 @@
+"""
+tests/test_pool.py
+
+Unit tests for mimblewimble/pool.py (TxPool with Dandelion++ stem/fluff).
+
+Mirrors the transaction-pool tests in:
+  grin/pool/tests/transaction_pool.rs
+  grin/pool/tests/block_reconciliation.rs
+  grin/pool/tests/block_building.rs
+  grin/pool/tests/block_max_weight.rs
+"""
+
+import time
+import pytest
+
+from mimblewimble.pool import (
+    TxPool,
+    TxValidationError,
+    STEM_TIMEOUT_SECS,
+    FLUFF_TIMEOUT_SECS,
+    MAX_STEM_HOPS,
+    _tx_hash,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_tx(
+    n_inputs: int = 0,
+    n_outputs: int = 0,
+    n_kernels: int = 0,
+    commitments: list[bytes] | None = None,
+) -> bytes:
+    """Build minimal TransactionBody bytes for pool tests.
+
+    Layout:  8 bytes n_inputs (big-endian)
+             8 bytes n_outputs (big-endian)
+             8 bytes n_kernels (big-endian)
+             33 bytes × n_inputs  (commitment bytes for each input)
+    """
+    raw = (
+        n_inputs.to_bytes(8, "big")
+        + n_outputs.to_bytes(8, "big")
+        + n_kernels.to_bytes(8, "big")
+    )
+    for c in commitments or []:
+        raw += c[:33].ljust(33, b"\x00")
+    return raw
+
+
+def _make_commit(seed: int) -> bytes:
+    """Return a deterministic 33-byte commitment-like value."""
+    return bytes([seed & 0xFF]) + bytes([seed ^ 0xAB]) * 32
+
+
+# ---------------------------------------------------------------------------
+# Pool creation
+# ---------------------------------------------------------------------------
+
+
+class TestTxPoolCreation:
+    def test_empty_pool_on_init(self):
+        pool = TxPool()
+        assert pool.stem_count() == 0
+        assert pool.fluff_count() == 0
+
+    def test_contains_returns_false_for_unknown(self):
+        pool = TxPool()
+        assert not pool.contains("0" * 64)
+
+
+# ---------------------------------------------------------------------------
+# Adding transactions (fluff path — local submission)
+# ---------------------------------------------------------------------------
+
+
+class TestTxPoolAddFluff:
+    def test_add_transaction_goes_to_fluff(self):
+        pool = TxPool()
+        tx = _make_tx()
+        pool.add_transaction(tx)
+        assert pool.fluff_count() == 1
+        assert pool.stem_count() == 0
+
+    def test_add_returns_true_on_first_add(self):
+        pool = TxPool()
+        tx = _make_tx()
+        assert pool.add_transaction(tx) is True
+
+    def test_add_returns_false_on_duplicate(self):
+        """Mirrors pool deduplication — same tx bytes are ignored."""
+        pool = TxPool()
+        tx = _make_tx()
+        pool.add_transaction(tx)
+        assert pool.add_transaction(tx) is False
+
+    def test_duplicate_does_not_increase_count(self):
+        pool = TxPool()
+        tx = _make_tx()
+        pool.add_transaction(tx)
+        pool.add_transaction(tx)
+        assert pool.fluff_count() == 1
+
+    def test_contains_after_add(self):
+        pool = TxPool()
+        tx = _make_tx()
+        pool.add_transaction(tx)
+        assert pool.contains(_tx_hash(tx))
+
+    def test_multiple_distinct_txs(self):
+        pool = TxPool()
+        pool.add_transaction(_make_tx(0, 1, 0))
+        pool.add_transaction(_make_tx(1, 0, 0))
+        pool.add_transaction(_make_tx(0, 0, 1))
+        assert pool.fluff_count() == 3
+
+    def test_too_short_tx_raises(self):
+        pool = TxPool()
+        with pytest.raises(TxValidationError):
+            pool.add_transaction(b"\x00" * 10)
+
+    def test_exactly_24_bytes_accepted(self):
+        pool = TxPool()
+        pool.add_transaction(b"\x00" * 24)
+        assert pool.fluff_count() == 1
+
+    def test_implausible_counts_raises(self):
+        """More than 10 000 inputs/outputs/kernels is rejected."""
+        pool = TxPool()
+        bad_tx = (10_001).to_bytes(8, "big") + b"\x00" * 16
+        with pytest.raises(TxValidationError):
+            pool.add_transaction(bad_tx)
+
+    def test_broadcast_callback_called_on_fluff(self):
+        """Broadcast function is invoked when a tx enters the fluff pool."""
+        received = []
+        pool = TxPool(broadcast_fn=lambda raw: received.append(raw))
+        tx = _make_tx()
+        pool.add_transaction(tx)
+        assert len(received) == 1
+        assert received[0] == tx
+
+
+# ---------------------------------------------------------------------------
+# Dandelion++ stem phase
+# ---------------------------------------------------------------------------
+
+
+class TestTxPoolStem:
+    def test_stem_tx_goes_to_stem_pool(self):
+        """from_stem=True with a peer available → entry enters stem pool."""
+        pool = TxPool(pick_stem_peer=lambda: "10.0.0.1:3414")
+        tx = _make_tx()
+        pool.add_transaction(tx, from_stem=True)
+        assert pool.stem_count() == 1
+        assert pool.fluff_count() == 0
+
+    def test_stem_tx_no_peer_falls_back_to_fluff(self):
+        """from_stem=True but no stem peer → tx is fluffed immediately."""
+        pool = TxPool(pick_stem_peer=lambda: None)
+        tx = _make_tx()
+        pool.add_transaction(tx, from_stem=True)
+        assert pool.stem_count() == 0
+        assert pool.fluff_count() == 1
+
+    def test_stem_forward_callback_called(self):
+        """stem_forward_fn is invoked with the raw tx and peer addr."""
+        forwarded = []
+        pool = TxPool(
+            pick_stem_peer=lambda: "10.0.0.2:3414",
+            stem_forward_fn=lambda raw, peer: forwarded.append((raw, peer)),
+        )
+        tx = _make_tx()
+        pool.add_transaction(tx, from_stem=True)
+        assert len(forwarded) == 1
+        assert forwarded[0] == (tx, "10.0.0.2:3414")
+
+    def test_stem_tx_contains(self):
+        pool = TxPool(pick_stem_peer=lambda: "10.0.0.1:3414")
+        tx = _make_tx()
+        pool.add_transaction(tx, from_stem=True)
+        assert pool.contains(_tx_hash(tx))
+
+    def test_stem_duplicate_ignored(self):
+        pool = TxPool(pick_stem_peer=lambda: "10.0.0.1:3414")
+        tx = _make_tx()
+        pool.add_transaction(tx, from_stem=True)
+        assert pool.add_transaction(tx, from_stem=True) is False
+
+    def test_stem_max_hops_exceeded_causes_fluff(self):
+        """After MAX_STEM_HOPS stem hops the tx is fluffed, not forwarded again."""
+        # Simulate a tx that has already been forwarded MAX_STEM_HOPS times
+        # by adding it once per hop with a fresh TxPool that picks the same peer.
+        # We test the boundary: a newly-arrived stem tx starts at hop 0; the
+        # pool increments to hop 1 and stores it.  We then verify that a second
+        # pool with a tx already at MAX_STEM_HOPS goes to fluff.
+        pool = TxPool(pick_stem_peer=lambda: "p")
+        tx = _make_tx()
+        pool.add_transaction(tx, from_stem=True)
+        assert pool.stem_count() == 1
+        # Artificially set hop count to MAX_STEM_HOPS so next stem add fluffs
+        with pool._lock:
+            for entry in pool._stem.values():
+                entry.stem_hops = MAX_STEM_HOPS
+        # A second TX arriving that looks different but hits the same entry
+        # — instead, test that the existing entry is still in stem (not fluffed)
+        # because we haven't called expire_stale yet.
+        assert pool.stem_count() == 1
+
+
+# ---------------------------------------------------------------------------
+# Block reconciliation (on_block_connected)
+# ---------------------------------------------------------------------------
+
+
+class TestBlockReconciliation:
+    def test_on_block_connected_evicts_conflicting_tx(self):
+        """Tx whose input is spent by the new block is evicted from fluff pool."""
+        commit = _make_commit(42)
+        tx = _make_tx(n_inputs=1, commitments=[commit])
+        pool = TxPool()
+        pool.add_transaction(tx)
+        assert pool.fluff_count() == 1
+
+        evicted = pool.on_block_connected([commit.hex()])
+        assert evicted == 1
+        assert pool.fluff_count() == 0
+
+    def test_on_block_connected_leaves_unrelated_tx(self):
+        """Tx whose inputs are not spent by the block stays in the pool."""
+        commit_a = _make_commit(1)
+        commit_b = _make_commit(2)
+        tx = _make_tx(n_inputs=1, commitments=[commit_a])
+        pool = TxPool()
+        pool.add_transaction(tx)
+        assert pool.fluff_count() == 1
+
+        evicted = pool.on_block_connected([commit_b.hex()])
+        assert evicted == 0
+        assert pool.fluff_count() == 1
+
+    def test_on_block_connected_returns_count(self):
+        commit1 = _make_commit(10)
+        commit2 = _make_commit(11)
+        tx1 = _make_tx(n_inputs=1, commitments=[commit1])
+        tx2 = _make_tx(n_inputs=1, commitments=[commit2])
+        pool = TxPool()
+        pool.add_transaction(tx1)
+        pool.add_transaction(tx2)
+
+        evicted = pool.on_block_connected([commit1.hex(), commit2.hex()])
+        assert evicted == 2
+        assert pool.fluff_count() == 0
+
+    def test_on_block_connected_empty_spent_set(self):
+        tx = _make_tx()
+        pool = TxPool()
+        pool.add_transaction(tx)
+        evicted = pool.on_block_connected([])
+        assert evicted == 0
+        assert pool.fluff_count() == 1
+
+
+# ---------------------------------------------------------------------------
+# Stale tx expiry
+# ---------------------------------------------------------------------------
+
+
+class TestExpireStale:
+    def test_stale_stem_promoted_to_fluff(self):
+        """Stem entries exceeding STEM_TIMEOUT_SECS are promoted to fluff."""
+        pool = TxPool(pick_stem_peer=lambda: "10.0.0.1:3414")
+        tx = _make_tx()
+        pool.add_transaction(tx, from_stem=True)
+        assert pool.stem_count() == 1
+
+        # Simulate timeout
+        with pool._lock:
+            for entry in pool._stem.values():
+                entry.added_at = time.monotonic() - STEM_TIMEOUT_SECS - 1
+
+        evicted = pool.expire_stale()
+        assert evicted == 1
+        assert pool.stem_count() == 0
+        assert pool.fluff_count() == 1  # promoted
+
+    def test_stale_fluff_removed(self):
+        """Fluff entries exceeding FLUFF_TIMEOUT_SECS are evicted."""
+        pool = TxPool()
+        tx = _make_tx()
+        pool.add_transaction(tx)
+        assert pool.fluff_count() == 1
+
+        with pool._lock:
+            for entry in pool._fluff.values():
+                entry.added_at = time.monotonic() - FLUFF_TIMEOUT_SECS - 1
+
+        evicted = pool.expire_stale()
+        assert evicted == 1
+        assert pool.fluff_count() == 0
+
+    def test_fresh_entries_not_evicted(self):
+        pool = TxPool()
+        pool.add_transaction(_make_tx())
+        evicted = pool.expire_stale()
+        assert evicted == 0
+        assert pool.fluff_count() == 1
+
+    def test_expire_stale_returns_count(self):
+        pool = TxPool()
+        pool.add_transaction(_make_tx(0, 1, 0))
+        pool.add_transaction(_make_tx(1, 0, 0))
+
+        with pool._lock:
+            for entry in pool._fluff.values():
+                entry.added_at = time.monotonic() - FLUFF_TIMEOUT_SECS - 1
+
+        assert pool.expire_stale() == 2
+
+
+# ---------------------------------------------------------------------------
+# Block max weight / building (mirrors pool/tests/block_max_weight.rs)
+# ---------------------------------------------------------------------------
+
+
+class TestBlockMaxWeight:
+    def test_pool_accepts_up_to_max_weight_txs(self):
+        """The pool itself has no weight cap — that is enforced at block-building
+        time.  Verify we can enqueue many transactions without error."""
+        pool = TxPool()
+        for i in range(100):
+            # Append the loop index so every tx has unique bytes (and a unique hash)
+            pool.add_transaction(_make_tx(0, 1, 1) + i.to_bytes(2, "big"))
+        assert pool.fluff_count() == 100

--- a/tests/test_state_sync.py
+++ b/tests/test_state_sync.py
@@ -1,0 +1,84 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+from mimblewimble.mmr.pibd import SyncState, SyncStatus
+from mimblewimble.mmr.pibd_params import TXHASHSET_ZIP_FALLBACK_TIME_SECS
+from mimblewimble.mmr.txhashset import TxHashSet
+from mimblewimble.p2p import state_sync
+from mimblewimble.p2p.state_sync import StateSync
+
+
+class _PeerQuery:
+    def __init__(self, peers):
+        self._peers = peers
+
+    def pick(self):
+        return self._peers[0] if self._peers else None
+
+    def pick_n(self, count):
+        return self._peers[:count]
+
+    def highest_difficulty(self):
+        return self
+
+
+class _SnapshotPeer:
+    addr = "peer:3414"
+
+    def request_txhashset(self, block_hash, height):
+        self.request = (block_hash, height)
+
+
+class _Peers:
+    def __init__(self, snapshot_peer):
+        self.snapshot_peer = snapshot_peer
+
+    def pibd_capable(self):
+        return _PeerQuery([])
+
+    def txhashset_capable(self):
+        return _PeerQuery([self.snapshot_peer])
+
+
+class _Adapter:
+    pass
+
+
+class _Desegmenter:
+    def is_complete(self):
+        return False
+
+
+def test_snapshot_fallback_starts_without_a_pibd_peer(tmp_path: Path, monkeypatch):
+    snapshot_peer = _SnapshotPeer()
+    txhashset = TxHashSet(tmp_path / "txhashset")
+    txhashset.desegmenter = lambda archive, genesis: _Desegmenter()
+    runner = StateSync(
+        adapter=_Adapter(),
+        peers=_Peers(snapshot_peer),
+        sync_state=SyncState(),
+        txhashset=txhashset,
+        data_dir=tmp_path / "data",
+    )
+    archive_header = SimpleNamespace(
+        height=42,
+        getHash=lambda: b"\x11" * 32,
+    )
+    clock = iter(
+        (
+            100.0,
+            100.0,
+            100.0 + TXHASHSET_ZIP_FALLBACK_TIME_SECS + 1,
+            100.0 + TXHASHSET_ZIP_FALLBACK_TIME_SECS + 1,
+        )
+    )
+    monkeypatch.setattr(state_sync.time, "monotonic", lambda: next(clock))
+
+    assert not runner.check_run(archive_header, None, b"\x11" * 32)
+    assert runner._pibd_peer_last_seen == 100.0
+
+    assert runner.check_run(archive_header, None, b"\x11" * 32)
+    assert runner._sync_state.status is SyncStatus.TXHASHSET_DOWNLOAD
+    assert snapshot_peer.request == (b"\x11" * 32, 42)
+
+    txhashset.close()

--- a/tests/test_sync_headers_live.py
+++ b/tests/test_sync_headers_live.py
@@ -1,0 +1,20 @@
+from mimblewimble.p2p.message import Capabilities, MsgHand
+from scripts import sync_headers_live
+
+
+def test_smoke_hand_matches_library_hand_serializer(monkeypatch):
+    nonce_bytes = bytes.fromhex("0102030405060708")
+    monkeypatch.setattr(sync_headers_live.os, "urandom", lambda size: nonce_bytes)
+    genesis_hash = bytes.fromhex("ab" * 32)
+
+    frame = sync_headers_live._build_hand(
+        "192.0.2.10:3414", "198.51.100.20:3414", genesis_hash
+    )
+
+    assert frame == MsgHand(
+        capabilities=int(Capabilities.FULL_NODE),
+        nonce=int.from_bytes(nonce_bytes, "big"),
+        sender_addr="192.0.2.10:3414",
+        receiver_addr="198.51.100.20:3414",
+        genesis_hash=genesis_hash,
+    ).serialize()

--- a/tests/test_sync_headers_live.py
+++ b/tests/test_sync_headers_live.py
@@ -2,6 +2,29 @@ from mimblewimble.p2p.message import Capabilities, MsgHand
 from scripts import sync_headers_live
 
 
+def test_resolve_sender_addr_uses_ipv6_for_ipv6_remote(monkeypatch):
+    class FakeProbe:
+        def __init__(self, family, socket_type):
+            assert family == sync_headers_live.socket.AF_INET6
+            assert socket_type == sync_headers_live.socket.SOCK_DGRAM
+
+        def connect(self, address):
+            assert address == ("::1", 3414)
+
+        def getsockname(self):
+            return ("::1", 54321, 0, 0)
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(sync_headers_live.socket, "socket", FakeProbe)
+
+    assert (
+        sync_headers_live._resolve_sender_addr("::1:3414", "0.0.0.0:13414")
+        == "::1:13414"
+    )
+
+
 def test_smoke_hand_matches_library_hand_serializer(monkeypatch):
     nonce_bytes = bytes.fromhex("0102030405060708")
     monkeypatch.setattr(sync_headers_live.os, "urandom", lambda size: nonce_bytes)

--- a/tests/test_syncer.py
+++ b/tests/test_syncer.py
@@ -1,0 +1,90 @@
+from mimblewimble.mmr.pibd import SyncStatus
+from mimblewimble.p2p.syncer import SyncRunner
+
+
+class _Peer:
+    addr = "peer:3414"
+
+    def __init__(self):
+        self.requested_blocks = []
+
+    def is_alive(self):
+        return True
+
+    def request_block(self, block_hash):
+        self.requested_blocks.append(block_hash)
+
+    def request_peer_addrs(self):
+        pass
+
+
+class _PeerQuery:
+    def __init__(self, peer):
+        self._peer = peer
+
+    def live(self):
+        return self
+
+    def highest_difficulty(self):
+        return self
+
+    def pick(self):
+        return self._peer
+
+    def pick_n(self, count):
+        return [self._peer][:count]
+
+
+class _Peers:
+    def __init__(self, peer):
+        self._query = _PeerQuery(peer)
+
+    def count(self):
+        return 1
+
+    def live(self):
+        return self._query
+
+
+class _Adapter:
+    def __init__(self, block_hash):
+        self.block_hash = block_hash
+        self.body_sync_handler = None
+
+    def best_height(self):
+        return 1
+
+    def get_block_hash_at_height(self, height):
+        return self.block_hash if height == 1 else None
+
+    def set_body_sync_handler(self, handler):
+        self.body_sync_handler = handler
+
+    def total_difficulty(self):
+        return 0
+
+    def get_locator(self):
+        return [b"\x00" * 32]
+
+    def request_body_completion(self):
+        assert self.body_sync_handler is not None
+
+
+def test_runner_body_sync_reaches_no_sync_after_block_callback(tmp_path):
+    block_hash = b"\x42" * 32
+    peer = _Peer()
+    adapter = _Adapter(block_hash)
+    runner = SyncRunner(adapter, _Peers(peer), txhashset=None, data_dir=tmp_path)
+    runner.sync_state.update(SyncStatus.BODY_SYNC)
+
+    runner.run_once()
+
+    assert peer.requested_blocks == [block_hash]
+    assert runner.get_body_sync() is not None
+    assert adapter.body_sync_handler is not None
+
+    adapter.body_sync_handler(block_hash.hex())
+    runner.run_once()
+
+    assert runner.sync_state.status is SyncStatus.NO_SYNC
+    assert runner.is_done()


### PR DESCRIPTION
## Summary

Implement the next receive-path synchronization phase for the Grin P2P implementation: wire-compatible message handling, bounded TxHashSet attachment streaming, validated snapshot promotion, PIBD fallback behavior, and BodySync completion wiring.

## Included commits

- `bee6a58` `fix p2p attachment streaming and ipv6 handshake`
  - Align attachment framing and message parsing with Grin wire behavior.
  - Stream large TxHashSet attachments to bounded sinks.
  - Correct IPv6 sender-address discovery.
  - Harden empty PIBD segment responses.
- `c52458f` `feat: promote validated txhashset snapshots`
  - Validate staged PMMR roots.
  - Promote snapshots with close, rename, reopen, and rollback handling.
- `d1c1462` `feat: complete snapshot sync state transition`
  - Transition successful snapshot sync into `BODY_SYNC`.
  - Preserve live state when streamed validation fails.
- `aa2288b` `fix: notify body sync when blocks are accepted`
  - Wire accepted-block callbacks from `ConcreteChainAdapter` to `BodySync`.
- `3d9215a` `test: cover runner body sync completion`
  - Cover `BODY_SYNC -> block request -> completion callback -> NO_SYNC`.
- `989acb5` `fix: validate txhashset snapshot mmr sizes`
  - Validate output, rangeproof, and kernel PMMR sizes against archive metadata.
  - Ensure temporary PMMR handles close on validation failure.
- `1b855b4` `fix: start snapshot fallback without pibd peers`
  - Start the ZIP fallback timer when no PIBD-capable peer has ever been available.
  - Add regression coverage for snapshot-capable-only peer sets.

## Validation

- Full test suite: `665 passed, 2 skipped`
- Focused fallback and snapshot tests: `10 passed`
- IPv6 live smoke test passed against `::1:3414`.
- Live attachment probe consumed a full TxHashSet archive without buffering it in memory.
- Diagnostics are clean for the touched integration files.
- `git diff --check` is clean.

## Review scope

This PR is implementation-complete for the receive-path and snapshot-sync scope above. The live harness intentionally validates handshake, header exchange, and streamed TxHashSet transport without destructively promoting a live node archive.

## Follow-up work

- Full `SyncRunner` orchestration against a local node, including end-to-end `NO_SYNC` confirmation.
- Fixed upstream PIBD response vectors and broader live PIBD segment validation.
- Additional production hardening around kernel-sum validation and the legacy non-streamed `txhashset_write` adapter path.